### PR TITLE
[CK-4] Add docs/context baseline: business, users, and glossary

### DIFF
--- a/docs/context/business.md
+++ b/docs/context/business.md
@@ -1,0 +1,48 @@
+# Business Context
+
+- **Last updated:** 2026-03-17
+
+---
+
+## What is CourtKnights?
+
+CourtKnights is an open-source platform for creating and managing padel leagues and competitions. It enables small clubs and communities to run their own leagues — handling player registration, team or pair management, match scheduling, result tracking, and statistics — without relying on expensive or overly complex external tools.
+
+## The problem
+
+Small padel clubs and communities today manage their leagues manually:
+
+- **No dedicated tooling** — competitions are organised via WhatsApp groups, shared spreadsheets, or paper. There is no single source of truth for standings, results, or schedules.
+- **No history or statistics** — match results are lost over time. Players have no way to track their performance, rivals, or progression across seasons.
+- **High operational friction** — organizers spend significant time coordinating logistics, resolving disputes, and updating standings by hand.
+
+CourtKnights removes this friction and gives communities a place to compete, track, and grow.
+
+## Who is it for?
+
+CourtKnights is designed for **small clubs and informal communities** that organise padel competitions. This includes:
+
+- Neighbourhood clubs running seasonal leagues
+- Company or corporate padel communities
+- Groups of friends running recurring tournaments
+- Any community that plays padel and wants to compete seriously without paying for enterprise software
+
+## What CourtKnights provides
+
+- Creation and management of padel leagues with different competition formats
+- Support for both **pair-based** and **team-based** competitions
+- Three tournament formats: **round-robin league**, **knockout**, and **group stage + knockout**
+- Player and team/pair management with roles and permissions
+- Match scheduling and result recording
+- Player and team statistics: standings, win rate, sets won, match history
+
+## Open source philosophy
+
+CourtKnights is community-driven and open source. Any club or developer can self-host it, contribute to it, or extend it. The project is licensed under **Apache 2.0**.
+
+## Out of scope (v1)
+
+- Payment processing or membership fees
+- Live match scoring or real-time updates
+- Sports other than padel (planned for future versions)
+- Mobile native applications (web-first)

--- a/docs/context/glossary.md
+++ b/docs/context/glossary.md
@@ -1,0 +1,107 @@
+# Domain Glossary
+
+- **Last updated:** 2026-03-17
+
+Terms are listed alphabetically. Add new terms here before using them in specs.
+
+---
+
+## C
+
+**Club**
+The top-level organisational unit. A club owns courts, runs competitions, and manages its members. A club has at least one Club Admin.
+
+**Club Admin**
+The user responsible for managing a club's resources, members, and overall configuration. See `docs/context/users.md`.
+
+**Competition**
+A generic term for any organised event — either a league, a knockout tournament, or a group stage + knockout. A competition always belongs to a club and has a defined format.
+
+**Competition Organiser**
+The user responsible for running a specific competition: configuring it, validating results, and resolving incidents. See `docs/context/users.md`.
+
+**Court**
+A physical padel court managed by a club. Courts are a resource that can be assigned to matches.
+
+---
+
+## F
+
+**Format**
+The structure that defines how a competition is played. CourtKnights supports three formats:
+- **League (round-robin):** every pair or team plays against every other. Final standings are determined by points.
+- **Knockout (elimination):** single-elimination bracket. Losers are eliminated; the last pair or team standing wins.
+- **Group stage + knockout:** pairs or teams are divided into groups for a round-robin phase; top finishers advance to a knockout phase.
+
+---
+
+## G
+
+**Group**
+A subdivision within the group stage phase of a competition. Each group runs an internal round-robin to determine which participants advance to the knockout phase.
+
+---
+
+## L
+
+**League**
+Refers to both (1) the round-robin competition format and (2) colloquially to any competition organised on the platform.
+
+---
+
+## M
+
+**Match**
+A single game between two pairs or two teams within a competition. A match has a result (sets, games) and a date.
+
+**Member**
+A user who belongs to a club. Members can participate in competitions run by that club.
+
+---
+
+## P
+
+**Padel**
+The racket sport this platform is built for. Played in pairs (2 vs 2) on an enclosed court. CourtKnights is designed primarily for padel; support for other sports may be added in future versions.
+
+**Pair**
+The unit of competition in pair-based competitions. A pair consists of exactly two players. Either player can perform administrative actions for the pair.
+
+**Player**
+An individual user participating in a competition. See `docs/context/users.md`.
+
+---
+
+## R
+
+**Result**
+The outcome of a match, expressed in sets and games (e.g. 6-4, 6-3). Results are recorded by participants and validated by the Competition Organiser.
+
+**Round**
+A stage within a competition where a set of matches is played. In a league, a round groups all matches played in a given week or date. In a knockout, a round is one elimination stage (e.g. quarter-finals).
+
+---
+
+## S
+
+**Season**
+A time-bounded edition of a competition. A club may run multiple seasons of the same league over time.
+
+**Standing**
+The ranked position of a pair or team within a competition at any point in time, calculated from match results.
+
+**Statistics**
+Aggregated performance data for a player or pair: number of matches played, wins, losses, win percentage, sets won, games won, and match history.
+
+---
+
+## T
+
+**Team**
+The unit of competition in team-based competitions. A team consists of multiple players and has one or more captains.
+
+**Team Captain**
+A player within a team who has administrative responsibilities for that team. See `docs/context/users.md`.
+
+**Tournament**
+Used interchangeably with *Competition* in everyday language. In the codebase and specs, prefer *Competition* for precision.

--- a/docs/context/users.md
+++ b/docs/context/users.md
@@ -1,0 +1,89 @@
+# User Types and Roles
+
+- **Last updated:** 2026-03-17
+
+---
+
+## Overview
+
+CourtKnights has two layers of roles: **club-level** roles that manage the organisation and its resources, and **competition-level** roles that operate within a specific league or tournament.
+
+---
+
+## Club-level roles
+
+### Club Admin
+
+The owner and administrator of a club on the platform.
+
+- Creates and configures the club
+- Manages physical resources (courts, facilities)
+- Handles logistical incidents (court availability, scheduling conflicts)
+- Manages club membership — who can join and with what role
+- Has full access to all competitions within the club
+
+**One or more per club.**
+
+---
+
+## Competition-level roles
+
+### Competition Organiser
+
+Responsible for running a specific league or tournament within a club.
+
+- Creates and configures the competition (format, rules, dates)
+- Validates and approves match results
+- Resolves disputes and incidents between participants
+- Manages the competition calendar and scheduling
+- Can be the same person as the Club Admin or a delegated member
+
+**One or more per competition.**
+
+### Team Captain
+
+Applies to **team-based competitions** only.
+
+- Represents a team within a competition
+- Manages team membership (adds/removes players)
+- Confirms match results on behalf of the team
+- A team can have one or more captains
+
+**One or more per team, in team-based competitions only.**
+
+### Player
+
+Any individual registered in a competition, either as part of a pair or a team.
+
+- Participates in matches
+- Views their own statistics and match history
+- In **pair-based competitions**: either player in the pair can perform administrative actions for that pair (no designated captain role)
+- In **team-based competitions**: acts under the team captain's authority
+
+**Many per competition.**
+
+---
+
+## Competition formats and role applicability
+
+| Role                  | Pair-based competition                 | Team-based competition |
+| --------------------- | -------------------------------------- | ---------------------- |
+| Club Admin            | ✓                                      | ✓                      |
+| Competition Organiser | ✓                                      | ✓                      |
+| Team Captain          | —                                      | ✓                      |
+| Player                | ✓ (any player in pair acts as captain) | ✓                      |
+
+---
+
+## Permission summary
+
+| Action                      | Club Admin | Competition Organiser | Team Captain | Player |
+| --------------------------- | ---------- | --------------------- | ------------ | ------ |
+| Create competition          | ✓          | —                     | —            | —      |
+| Configure competition rules | ✓          | ✓                     | —            | —      |
+| Validate match results      | ✓          | ✓                     | —            | —      |
+| Resolve incidents           | ✓          | ✓                     | —            | —      |
+| Manage team members         | ✓          | ✓                     | ✓            | —      |
+| Confirm match result (pair) | ✓          | ✓                     | —            | ✓      |
+| View statistics             | ✓          | ✓                     | ✓            | ✓      |
+| Manage court resources      | ✓          | —                     | —            | —      |


### PR DESCRIPTION
## Summary

- Creates `docs/context/business.md` — product overview, problem statement, target audience, scope, and out-of-scope for v1
- Creates `docs/context/users.md` — 4 roles (Club Admin, Competition Organiser, Team Captain, Player) with applicability by competition format and full permission table
- Creates `docs/context/glossary.md` — ~20 domain terms ordered alphabetically, covering the core padel competition domain

## Why

These documents are step 1 of the mandatory SDD reading order. Without them, every feature spec would need to re-explain the domain from scratch.

## Test plan

- [ ] Review `business.md` — problem, audience, and scope accurately describe the project
- [ ] Review `users.md` — roles, permissions, and format applicability are correct
- [ ] Review `glossary.md` — terms are accurate and cover the core domain vocabulary

Closes #4