### PR TITLE
[CK-8] T-02: Database schema — users and personal_access_tokens

### DIFF
--- a/Dependency.md
+++ b/Dependency.md
@@ -1,0 +1,27 @@
+# CourtKnights — Direct Dependencies
+
+All direct dependencies must be registered here before use.
+Format: **Name** | **Purpose** | **License**
+
+---
+
+## Go
+
+| Name | Purpose | License |
+|------|---------|---------|
+| `github.com/google/uuid` | UUID generation and parsing for entity IDs | BSD-3-Clause |
+| `github.com/stretchr/testify` | Test assertions and mock framework (`assert`, `require`, `mock`) | MIT |
+
+---
+
+## To be added (approved in spec)
+
+| Name | Purpose | License | Approved in |
+|------|---------|---------|-------------|
+| `golang.org/x/oauth2` | OAuth2 client — redirect flow and device flow for Google and GitHub | BSD-3-Clause | `docs/specs/FEATURE_authentication/02_architecture.md` |
+| `github.com/golang-jwt/jwt/v5` | JWT signing and validation (HS256) | MIT | `docs/specs/FEATURE_authentication/02_architecture.md` |
+| `github.com/labstack/echo/v4` | HTTP API framework (ADR-001) | MIT | `docs/decisions/ADR-001_http-framework-echo.md` |
+| `github.com/spf13/cobra` | CLI framework (ADR-002) | Apache-2.0 | `docs/decisions/ADR-002_cli-cobra-viper.md` |
+| `github.com/spf13/viper` | Configuration management (ADR-002) | MIT | `docs/decisions/ADR-002_cli-cobra-viper.md` |
+| `github.com/lib/pq` or `github.com/jackc/pgx/v5` | PostgreSQL driver (ADR-003) | MIT | `docs/decisions/ADR-003_database-postgresql.md` |
+| `github.com/testcontainers/testcontainers-go` | Integration test containers (ADR-004) | MIT | `docs/decisions/ADR-004_testcontainers.md` |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+BINARY_NAME   := courtknights-api
+BUILD_DIR     := build
+CMD_SERVER    := ./cmd/server
+
+.PHONY: all build run test test-int test-all lint fmt clean
+
+## all: build the binary (default target)
+all: build
+
+## build: compile the backend binary
+build:
+	go build -o $(BUILD_DIR)/$(BINARY_NAME) $(CMD_SERVER)
+
+## run: run the backend server
+run:
+	go run $(CMD_SERVER)
+
+## test: run unit tests (no external processes required)
+test:
+	go test -race -count=1 ./...
+
+## test-int: run integration tests (requires Docker for Testcontainers)
+test-int:
+	go test -race -count=1 -tags integration ./...
+
+## test-all: run unit and integration tests
+test-all: test test-int
+
+## lint: run golangci-lint
+lint:
+	golangci-lint run ./...
+
+## fmt: format all Go files
+fmt:
+	gofmt -w .
+
+## clean: remove build artefacts
+clean:
+	rm -rf $(BUILD_DIR)/$(BINARY_NAME)

--- a/db/migrations/001_create_users.down.sql
+++ b/db/migrations/001_create_users.down.sql
@@ -1,0 +1,3 @@
+-- Migration 001 (down): drop the users table.
+
+DROP TABLE IF EXISTS users;

--- a/db/migrations/001_create_users.up.sql
+++ b/db/migrations/001_create_users.up.sql
@@ -1,0 +1,15 @@
+-- Migration 001 (up): create the users table.
+
+CREATE TABLE IF NOT EXISTS users (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    email       VARCHAR(255) NOT NULL UNIQUE,
+    name        VARCHAR(255) NOT NULL,
+    role        VARCHAR(50)  NOT NULL DEFAULT 'user'
+                             CHECK (role IN ('admin', 'user')),
+    provider    VARCHAR(50)  NOT NULL
+                             CHECK (provider IN ('google', 'github', 'pat')),
+    provider_id VARCHAR(255) NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (provider, provider_id)
+);

--- a/db/migrations/002_create_personal_access_tokens.down.sql
+++ b/db/migrations/002_create_personal_access_tokens.down.sql
@@ -1,0 +1,3 @@
+-- Migration 002 (down): drop the personal_access_tokens table.
+
+DROP TABLE IF EXISTS personal_access_tokens;

--- a/db/migrations/002_create_personal_access_tokens.up.sql
+++ b/db/migrations/002_create_personal_access_tokens.up.sql
@@ -1,0 +1,9 @@
+-- Migration 002 (up): create the personal_access_tokens table.
+
+CREATE TABLE IF NOT EXISTS personal_access_tokens (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    key_hash    VARCHAR(255) NOT NULL,
+    salt        VARCHAR(255) NOT NULL,
+    expires_at  TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);

--- a/db/schema/personal_access_tokens.sql
+++ b/db/schema/personal_access_tokens.sql
@@ -1,0 +1,11 @@
+-- personal_access_tokens: stores hashed PAT credentials.
+-- The raw token value is NEVER stored — only key_hash + salt.
+-- A PAT is linked to exactly one user via users.provider_id = personal_access_tokens.id.
+
+CREATE TABLE IF NOT EXISTS personal_access_tokens (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    key_hash    VARCHAR(255) NOT NULL,
+    salt        VARCHAR(255) NOT NULL,
+    expires_at  TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);

--- a/db/schema/users.sql
+++ b/db/schema/users.sql
@@ -1,0 +1,17 @@
+-- users: core identity table.
+-- Each row represents one authenticated user.
+-- A user is uniquely identified by (provider, provider_id).
+
+CREATE TABLE IF NOT EXISTS users (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    email       VARCHAR(255) NOT NULL UNIQUE,
+    name        VARCHAR(255) NOT NULL,
+    role        VARCHAR(50)  NOT NULL DEFAULT 'user'
+                             CHECK (role IN ('admin', 'user')),
+    provider    VARCHAR(50)  NOT NULL
+                             CHECK (provider IN ('google', 'github', 'pat')),
+    provider_id VARCHAR(255) NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (provider, provider_id)
+);

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/courtknights/courtknights
+
+go 1.24.2
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/domain/ckerrors/auth.go
+++ b/internal/domain/ckerrors/auth.go
@@ -1,0 +1,23 @@
+// Package ckerrors defines sentinel errors shared across the domain layer.
+// No external imports are allowed in this package.
+package ckerrors
+
+import "errors"
+
+// Authentication and authorisation sentinel errors.
+var (
+	// ErrUserNotFound is returned when a user lookup produces no result.
+	ErrUserNotFound = errors.New("user not found")
+
+	// ErrPATNotFound is returned when a PAT lookup produces no result.
+	ErrPATNotFound = errors.New("personal access token not found")
+
+	// ErrPATExpired is returned when a PAT exists but has passed its expiry time.
+	ErrPATExpired = errors.New("personal access token expired")
+
+	// ErrInvalidPAT is returned when the provided raw token does not match any stored hash.
+	ErrInvalidPAT = errors.New("invalid personal access token")
+
+	// ErrUnauthorized is returned when a request lacks valid credentials.
+	ErrUnauthorized = errors.New("unauthorized")
+)

--- a/internal/domain/pat/pat.go
+++ b/internal/domain/pat/pat.go
@@ -1,0 +1,33 @@
+// Package pat defines the PersonalAccessToken domain entity.
+package pat
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PAT represents a Personal Access Token used to authenticate without OAuth2.
+// The raw token value is never stored; only the hash and salt are persisted.
+type PAT struct {
+	// ID is the internal UUID primary key.
+	ID uuid.UUID
+	// KeyHash is the hashed representation of the raw token.
+	KeyHash string
+	// Salt is the random salt used when hashing the raw token.
+	Salt string
+	// ExpiresAt is the optional expiry time of the token.
+	// A nil value means the token never expires.
+	ExpiresAt *time.Time
+	// CreatedAt is the timestamp when the PAT was created.
+	CreatedAt time.Time
+}
+
+// IsExpired reports whether the PAT has passed its expiry time.
+// A PAT without an expiry (ExpiresAt == nil) is never considered expired.
+func (p *PAT) IsExpired() bool {
+	if p.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(*p.ExpiresAt)
+}

--- a/internal/domain/pat/pat_test.go
+++ b/internal/domain/pat/pat_test.go
@@ -1,0 +1,49 @@
+package pat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPAT_IsExpired(t *testing.T) {
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	tests := []struct {
+		name      string
+		expiresAt *time.Time
+		expected  bool
+	}{
+		{
+			name:      "no expiry is never expired",
+			expiresAt: nil,
+			expected:  false,
+		},
+		{
+			name:      "future expiry is not expired",
+			expiresAt: &future,
+			expected:  false,
+		},
+		{
+			name:      "past expiry is expired",
+			expiresAt: &past,
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PAT{
+				ID:        uuid.New(),
+				KeyHash:   "somehash",
+				Salt:      "somesalt",
+				ExpiresAt: tt.expiresAt,
+				CreatedAt: time.Now(),
+			}
+			assert.Equal(t, tt.expected, p.IsExpired())
+		})
+	}
+}

--- a/internal/domain/pat/repository.go
+++ b/internal/domain/pat/repository.go
@@ -1,0 +1,25 @@
+package pat
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// PATRepository defines the persistence operations for the PAT entity.
+// Implementations live in internal/infrastructure/postgres.
+type PATRepository interface {
+	// FindAll returns all PATs stored in the system.
+	FindAll(ctx context.Context) ([]*PAT, error)
+
+	// FindByID returns the PAT with the given UUID.
+	// Returns ckerrors.ErrPATNotFound if no PAT exists with that ID.
+	FindByID(ctx context.Context, id uuid.UUID) (*PAT, error)
+
+	// Save persists a new PAT record and returns it with the assigned ID and timestamps.
+	Save(ctx context.Context, p *PAT) (*PAT, error)
+
+	// Delete removes the PAT with the given UUID.
+	// Returns ckerrors.ErrPATNotFound if no PAT exists with that ID.
+	Delete(ctx context.Context, id uuid.UUID) error
+}

--- a/internal/domain/user/repository.go
+++ b/internal/domain/user/repository.go
@@ -1,0 +1,24 @@
+package user
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// UserRepository defines the persistence operations for the User entity.
+// Implementations live in internal/infrastructure/postgres.
+type UserRepository interface {
+	// FindByID returns the user with the given UUID.
+	// Returns ckerrors.ErrUserNotFound if no user exists with that ID.
+	FindByID(ctx context.Context, id uuid.UUID) (*User, error)
+
+	// FindByProvider returns the user that matches the given provider and provider-scoped ID.
+	// Returns ckerrors.ErrUserNotFound if no matching user exists.
+	FindByProvider(ctx context.Context, provider Provider, providerID string) (*User, error)
+
+	// Upsert creates the user if no row exists for (provider, provider_id),
+	// or updates name, email, and updated_at if it does.
+	// Returns the persisted User (with ID and timestamps populated).
+	Upsert(ctx context.Context, u *User) (*User, error)
+}

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -1,0 +1,57 @@
+// Package user defines the User domain entity and its associated types.
+package user
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Role represents the access level of a user within the platform.
+type Role string
+
+const (
+	// RoleAdmin grants elevated permissions (e.g. PAT management, role promotion).
+	RoleAdmin Role = "admin"
+	// RoleUser is the default role for regular platform users.
+	RoleUser Role = "user"
+)
+
+// Provider identifies the authentication provider used to create a user account.
+type Provider string
+
+const (
+	// ProviderGoogle identifies users authenticated via Google OAuth2.
+	ProviderGoogle Provider = "google"
+	// ProviderGitHub identifies users authenticated via GitHub OAuth2.
+	ProviderGitHub Provider = "github"
+	// ProviderPAT identifies users created for PAT-only authentication (e.g. bootstrap admin).
+	ProviderPAT Provider = "pat"
+)
+
+// User is the core identity entity of the platform.
+// Each User is linked to exactly one external identity (provider + provider_id).
+type User struct {
+	// ID is the internal UUID primary key.
+	ID uuid.UUID
+	// Email is the user's email address. Always non-null.
+	Email string
+	// Name is the user's display name.
+	Name string
+	// Role determines the user's access level.
+	Role Role
+	// Provider is the authentication provider that created this account.
+	Provider Provider
+	// ProviderID is the unique identifier within the provider's namespace.
+	// For PAT users this is set to the linked PAT's UUID.
+	ProviderID string
+	// CreatedAt is the timestamp when the user was created.
+	CreatedAt time.Time
+	// UpdatedAt is the timestamp of the last update.
+	UpdatedAt time.Time
+}
+
+// IsAdmin reports whether the user has the admin role.
+func (u *User) IsAdmin() bool {
+	return u.Role == RoleAdmin
+}

--- a/internal/domain/user/user_test.go
+++ b/internal/domain/user/user_test.go
@@ -1,0 +1,55 @@
+package user
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUser_IsAdmin(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     Role
+		expected bool
+	}{
+		{
+			name:     "admin role returns true",
+			role:     RoleAdmin,
+			expected: true,
+		},
+		{
+			name:     "user role returns false",
+			role:     RoleUser,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &User{
+				ID:         uuid.New(),
+				Email:      "test@example.com",
+				Name:       "Test User",
+				Role:       tt.role,
+				Provider:   ProviderGoogle,
+				ProviderID: "google-123",
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+			}
+			assert.Equal(t, tt.expected, u.IsAdmin())
+		})
+	}
+}
+
+func TestRole_Constants(t *testing.T) {
+	assert.Equal(t, Role("admin"), RoleAdmin)
+	assert.Equal(t, Role("user"), RoleUser)
+}
+
+func TestProvider_Constants(t *testing.T) {
+	assert.Equal(t, Provider("google"), ProviderGoogle)
+	assert.Equal(t, Provider("github"), ProviderGitHub)
+	assert.Equal(t, Provider("pat"), ProviderPAT)
+}


### PR DESCRIPTION
## Summary

Implements T-02 from the authentication feature spec.

- `db/schema/users.sql` — canonical schema for the `users` table (role + provider CHECK constraints, unique index on `(provider, provider_id)`)
- `db/schema/personal_access_tokens.sql` — canonical schema for the `personal_access_tokens` table (raw key never stored, nullable `expires_at`)
- `db/migrations/001_create_users.up.sql` / `.down.sql`
- `db/migrations/002_create_personal_access_tokens.up.sql` / `.down.sql`

## Test plan

- [x] Migrations apply in order against a fresh PostgreSQL instance
- [x] Down migrations reverse cleanly (no FK violations — PAT link is logical via `provider_id`)
- [x] CHECK constraints enforce valid `role` and `provider` values

Closes #8
Spec: docs/specs/FEATURE_authentication/03_tasks.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)