### PR TITLE
[CK-11] T-05: Infrastructure — OAuth2 adapters (Google + GitHub)

### DIFF
--- a/Dependency.md
+++ b/Dependency.md
@@ -1,0 +1,27 @@
+# CourtKnights — Direct Dependencies
+
+All direct dependencies must be registered here before use.
+Format: **Name** | **Purpose** | **License**
+
+---
+
+## Go
+
+| Name | Purpose | License |
+|------|---------|---------|
+| `github.com/google/uuid` | UUID generation and parsing for entity IDs | BSD-3-Clause |
+| `github.com/stretchr/testify` | Test assertions and mock framework (`assert`, `require`, `mock`) | MIT |
+
+---
+
+## To be added (approved in spec)
+
+| Name | Purpose | License | Approved in |
+|------|---------|---------|-------------|
+| `golang.org/x/oauth2` | OAuth2 client — redirect flow and device flow for Google and GitHub | BSD-3-Clause | `docs/specs/FEATURE_authentication/02_architecture.md` |
+| `github.com/golang-jwt/jwt/v5` | JWT signing and validation (HS256) | MIT | `docs/specs/FEATURE_authentication/02_architecture.md` |
+| `github.com/labstack/echo/v4` | HTTP API framework (ADR-001) | MIT | `docs/decisions/ADR-001_http-framework-echo.md` |
+| `github.com/spf13/cobra` | CLI framework (ADR-002) | Apache-2.0 | `docs/decisions/ADR-002_cli-cobra-viper.md` |
+| `github.com/spf13/viper` | Configuration management (ADR-002) | MIT | `docs/decisions/ADR-002_cli-cobra-viper.md` |
+| `github.com/lib/pq` or `github.com/jackc/pgx/v5` | PostgreSQL driver (ADR-003) | MIT | `docs/decisions/ADR-003_database-postgresql.md` |
+| `github.com/testcontainers/testcontainers-go` | Integration test containers (ADR-004) | MIT | `docs/decisions/ADR-004_testcontainers.md` |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+BINARY_NAME   := courtknights-api
+BUILD_DIR     := build
+CMD_SERVER    := ./cmd/server
+
+.PHONY: all build run test test-int test-all lint fmt clean
+
+## all: build the binary (default target)
+all: build
+
+## build: compile the backend binary
+build:
+	go build -o $(BUILD_DIR)/$(BINARY_NAME) $(CMD_SERVER)
+
+## run: run the backend server
+run:
+	go run $(CMD_SERVER)
+
+## test: run unit tests (no external processes required)
+test:
+	go test -race -count=1 ./...
+
+## test-int: run integration tests (requires Docker for Testcontainers)
+test-int:
+	go test -race -count=1 -tags integration ./...
+
+## test-all: run unit and integration tests
+test-all: test test-int
+
+## lint: run golangci-lint
+lint:
+	golangci-lint run ./...
+
+## fmt: format all Go files
+fmt:
+	gofmt -w .
+
+## clean: remove build artefacts
+clean:
+	rm -rf $(BUILD_DIR)/$(BINARY_NAME)

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,15 @@
 module github.com/courtknights/courtknights
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/oauth2 v0.36.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/courtknights/courtknights
+
+go 1.24.2
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -6,6 +8,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/domain/ckerrors/auth.go
+++ b/internal/domain/ckerrors/auth.go
@@ -1,0 +1,23 @@
+// Package ckerrors defines sentinel errors shared across the domain layer.
+// No external imports are allowed in this package.
+package ckerrors
+
+import "errors"
+
+// Authentication and authorisation sentinel errors.
+var (
+	// ErrUserNotFound is returned when a user lookup produces no result.
+	ErrUserNotFound = errors.New("user not found")
+
+	// ErrPATNotFound is returned when a PAT lookup produces no result.
+	ErrPATNotFound = errors.New("personal access token not found")
+
+	// ErrPATExpired is returned when a PAT exists but has passed its expiry time.
+	ErrPATExpired = errors.New("personal access token expired")
+
+	// ErrInvalidPAT is returned when the provided raw token does not match any stored hash.
+	ErrInvalidPAT = errors.New("invalid personal access token")
+
+	// ErrUnauthorized is returned when a request lacks valid credentials.
+	ErrUnauthorized = errors.New("unauthorized")
+)

--- a/internal/domain/pat/pat.go
+++ b/internal/domain/pat/pat.go
@@ -1,0 +1,33 @@
+// Package pat defines the PersonalAccessToken domain entity.
+package pat
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PAT represents a Personal Access Token used to authenticate without OAuth2.
+// The raw token value is never stored; only the hash and salt are persisted.
+type PAT struct {
+	// ID is the internal UUID primary key.
+	ID uuid.UUID
+	// KeyHash is the hashed representation of the raw token.
+	KeyHash string
+	// Salt is the random salt used when hashing the raw token.
+	Salt string
+	// ExpiresAt is the optional expiry time of the token.
+	// A nil value means the token never expires.
+	ExpiresAt *time.Time
+	// CreatedAt is the timestamp when the PAT was created.
+	CreatedAt time.Time
+}
+
+// IsExpired reports whether the PAT has passed its expiry time.
+// A PAT without an expiry (ExpiresAt == nil) is never considered expired.
+func (p *PAT) IsExpired() bool {
+	if p.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(*p.ExpiresAt)
+}

--- a/internal/domain/pat/pat_test.go
+++ b/internal/domain/pat/pat_test.go
@@ -1,0 +1,49 @@
+package pat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPAT_IsExpired(t *testing.T) {
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	tests := []struct {
+		name      string
+		expiresAt *time.Time
+		expected  bool
+	}{
+		{
+			name:      "no expiry is never expired",
+			expiresAt: nil,
+			expected:  false,
+		},
+		{
+			name:      "future expiry is not expired",
+			expiresAt: &future,
+			expected:  false,
+		},
+		{
+			name:      "past expiry is expired",
+			expiresAt: &past,
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PAT{
+				ID:        uuid.New(),
+				KeyHash:   "somehash",
+				Salt:      "somesalt",
+				ExpiresAt: tt.expiresAt,
+				CreatedAt: time.Now(),
+			}
+			assert.Equal(t, tt.expected, p.IsExpired())
+		})
+	}
+}

--- a/internal/domain/pat/repository.go
+++ b/internal/domain/pat/repository.go
@@ -1,0 +1,25 @@
+package pat
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// PATRepository defines the persistence operations for the PAT entity.
+// Implementations live in internal/infrastructure/postgres.
+type PATRepository interface {
+	// FindAll returns all PATs stored in the system.
+	FindAll(ctx context.Context) ([]*PAT, error)
+
+	// FindByID returns the PAT with the given UUID.
+	// Returns ckerrors.ErrPATNotFound if no PAT exists with that ID.
+	FindByID(ctx context.Context, id uuid.UUID) (*PAT, error)
+
+	// Save persists a new PAT record and returns it with the assigned ID and timestamps.
+	Save(ctx context.Context, p *PAT) (*PAT, error)
+
+	// Delete removes the PAT with the given UUID.
+	// Returns ckerrors.ErrPATNotFound if no PAT exists with that ID.
+	Delete(ctx context.Context, id uuid.UUID) error
+}

--- a/internal/domain/user/repository.go
+++ b/internal/domain/user/repository.go
@@ -1,0 +1,24 @@
+package user
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// UserRepository defines the persistence operations for the User entity.
+// Implementations live in internal/infrastructure/postgres.
+type UserRepository interface {
+	// FindByID returns the user with the given UUID.
+	// Returns ckerrors.ErrUserNotFound if no user exists with that ID.
+	FindByID(ctx context.Context, id uuid.UUID) (*User, error)
+
+	// FindByProvider returns the user that matches the given provider and provider-scoped ID.
+	// Returns ckerrors.ErrUserNotFound if no matching user exists.
+	FindByProvider(ctx context.Context, provider Provider, providerID string) (*User, error)
+
+	// Upsert creates the user if no row exists for (provider, provider_id),
+	// or updates name, email, and updated_at if it does.
+	// Returns the persisted User (with ID and timestamps populated).
+	Upsert(ctx context.Context, u *User) (*User, error)
+}

--- a/internal/domain/user/user.go
+++ b/internal/domain/user/user.go
@@ -1,0 +1,57 @@
+// Package user defines the User domain entity and its associated types.
+package user
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Role represents the access level of a user within the platform.
+type Role string
+
+const (
+	// RoleAdmin grants elevated permissions (e.g. PAT management, role promotion).
+	RoleAdmin Role = "admin"
+	// RoleUser is the default role for regular platform users.
+	RoleUser Role = "user"
+)
+
+// Provider identifies the authentication provider used to create a user account.
+type Provider string
+
+const (
+	// ProviderGoogle identifies users authenticated via Google OAuth2.
+	ProviderGoogle Provider = "google"
+	// ProviderGitHub identifies users authenticated via GitHub OAuth2.
+	ProviderGitHub Provider = "github"
+	// ProviderPAT identifies users created for PAT-only authentication (e.g. bootstrap admin).
+	ProviderPAT Provider = "pat"
+)
+
+// User is the core identity entity of the platform.
+// Each User is linked to exactly one external identity (provider + provider_id).
+type User struct {
+	// ID is the internal UUID primary key.
+	ID uuid.UUID
+	// Email is the user's email address. Always non-null.
+	Email string
+	// Name is the user's display name.
+	Name string
+	// Role determines the user's access level.
+	Role Role
+	// Provider is the authentication provider that created this account.
+	Provider Provider
+	// ProviderID is the unique identifier within the provider's namespace.
+	// For PAT users this is set to the linked PAT's UUID.
+	ProviderID string
+	// CreatedAt is the timestamp when the user was created.
+	CreatedAt time.Time
+	// UpdatedAt is the timestamp of the last update.
+	UpdatedAt time.Time
+}
+
+// IsAdmin reports whether the user has the admin role.
+func (u *User) IsAdmin() bool {
+	return u.Role == RoleAdmin
+}

--- a/internal/domain/user/user_test.go
+++ b/internal/domain/user/user_test.go
@@ -1,0 +1,55 @@
+package user
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUser_IsAdmin(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     Role
+		expected bool
+	}{
+		{
+			name:     "admin role returns true",
+			role:     RoleAdmin,
+			expected: true,
+		},
+		{
+			name:     "user role returns false",
+			role:     RoleUser,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := &User{
+				ID:         uuid.New(),
+				Email:      "test@example.com",
+				Name:       "Test User",
+				Role:       tt.role,
+				Provider:   ProviderGoogle,
+				ProviderID: "google-123",
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+			}
+			assert.Equal(t, tt.expected, u.IsAdmin())
+		})
+	}
+}
+
+func TestRole_Constants(t *testing.T) {
+	assert.Equal(t, Role("admin"), RoleAdmin)
+	assert.Equal(t, Role("user"), RoleUser)
+}
+
+func TestProvider_Constants(t *testing.T) {
+	assert.Equal(t, Provider("google"), ProviderGoogle)
+	assert.Equal(t, Provider("github"), ProviderGitHub)
+	assert.Equal(t, Provider("pat"), ProviderPAT)
+}

--- a/internal/infrastructure/oauth2/github.go
+++ b/internal/infrastructure/oauth2/github.go
@@ -1,0 +1,139 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
+)
+
+const githubUserURL = "https://api.github.com/user"
+
+// GitHubConfig holds the configuration for the GitHub OAuth2 provider.
+type GitHubConfig struct {
+	// ClientID is the GitHub OAuth App client ID.
+	ClientID string
+	// ClientSecret is the GitHub OAuth App client secret.
+	ClientSecret string
+	// RedirectURL is the callback URL registered in the GitHub OAuth App.
+	RedirectURL string
+}
+
+// GitHubProvider implements Provider for GitHub OAuth2.
+type GitHubProvider struct {
+	cfg        *oauth2.Config
+	httpClient *http.Client
+}
+
+// NewGitHub returns a GitHubProvider configured with the given credentials.
+// httpClient is optional; if nil, http.DefaultClient is used.
+func NewGitHub(cfg GitHubConfig, httpClient *http.Client) *GitHubProvider {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &GitHubProvider{
+		cfg: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURL:  cfg.RedirectURL,
+			Scopes:       []string{"read:user", "user:email"},
+			Endpoint:     github.Endpoint,
+		},
+		httpClient: httpClient,
+	}
+}
+
+// ctxWithClient injects httpClient into the context so the oauth2 library uses
+// it for all HTTP calls (token exchange, device auth, etc.).
+func (g *GitHubProvider) ctxWithClient(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, g.httpClient)
+}
+
+// AuthCodeURL implements Provider.
+func (g *GitHubProvider) AuthCodeURL(state string) string {
+	return g.cfg.AuthCodeURL(state, oauth2.AccessTypeOnline)
+}
+
+// Exchange implements Provider.
+func (g *GitHubProvider) Exchange(ctx context.Context, code string) (*UserInfo, error) {
+	ctx = g.ctxWithClient(ctx)
+	token, err := g.cfg.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("github: exchange: %w", err)
+	}
+	return g.fetchUserInfo(ctx, token.AccessToken)
+}
+
+// DeviceAuth implements Provider using GitHub's device authorisation flow.
+func (g *GitHubProvider) DeviceAuth(ctx context.Context) (*DeviceAuthResponse, error) {
+	ctx = g.ctxWithClient(ctx)
+	resp, err := g.cfg.DeviceAuth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("github: device auth: %w", err)
+	}
+	return &DeviceAuthResponse{
+		DeviceCode:      resp.DeviceCode,
+		UserCode:        resp.UserCode,
+		VerificationURI: resp.VerificationURI,
+		ExpiresIn:       int(resp.Expiry.Unix()),
+		Interval:        int(resp.Interval),
+	}, nil
+}
+
+// DevicePoll implements Provider.
+// Returns ErrAuthorizationPending while the user has not yet approved the request.
+func (g *GitHubProvider) DevicePoll(ctx context.Context, deviceCode string) (*UserInfo, error) {
+	ctx = g.ctxWithClient(ctx)
+	deviceResp := &oauth2.DeviceAuthResponse{DeviceCode: deviceCode}
+	token, err := g.cfg.DeviceAccessToken(ctx, deviceResp)
+	if err != nil {
+		return nil, fmt.Errorf("github: device poll: %w: %w", ErrAuthorizationPending, err)
+	}
+	return g.fetchUserInfo(ctx, token.AccessToken)
+}
+
+// fetchUserInfo retrieves the authenticated user's profile from the GitHub API.
+func (g *GitHubProvider) fetchUserInfo(ctx context.Context, accessToken string) (*UserInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubUserURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github: userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github: userinfo: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("github: read userinfo: %w", err)
+	}
+
+	var info struct {
+		ID    int64  `json:"id"`
+		Login string `json:"login"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("github: parse userinfo: %w", err)
+	}
+
+	name := info.Name
+	if name == "" {
+		name = info.Login
+	}
+
+	return &UserInfo{
+		ProviderID: fmt.Sprintf("%d", info.ID),
+		Email:      info.Email,
+		Name:       name,
+	}, nil
+}

--- a/internal/infrastructure/oauth2/google.go
+++ b/internal/infrastructure/oauth2/google.go
@@ -1,0 +1,132 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const googleUserInfoURL = "https://www.googleapis.com/oauth2/v3/userinfo"
+
+// GoogleConfig holds the configuration for the Google OAuth2 provider.
+type GoogleConfig struct {
+	// ClientID is the Google OAuth2 client ID.
+	ClientID string
+	// ClientSecret is the Google OAuth2 client secret.
+	ClientSecret string
+	// RedirectURL is the callback URL registered in Google Cloud Console.
+	RedirectURL string
+}
+
+// GoogleProvider implements Provider for Google OAuth2.
+type GoogleProvider struct {
+	cfg        *oauth2.Config
+	httpClient *http.Client
+}
+
+// NewGoogle returns a GoogleProvider configured with the given credentials.
+// httpClient is optional; if nil, http.DefaultClient is used.
+func NewGoogle(cfg GoogleConfig, httpClient *http.Client) *GoogleProvider {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &GoogleProvider{
+		cfg: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURL:  cfg.RedirectURL,
+			Scopes:       []string{"openid", "email", "profile"},
+			Endpoint:     google.Endpoint,
+		},
+		httpClient: httpClient,
+	}
+}
+
+// ctxWithClient injects httpClient into the context so the oauth2 library uses
+// it for all HTTP calls (token exchange, device auth, etc.).
+func (g *GoogleProvider) ctxWithClient(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, g.httpClient)
+}
+
+// AuthCodeURL implements Provider.
+func (g *GoogleProvider) AuthCodeURL(state string) string {
+	return g.cfg.AuthCodeURL(state, oauth2.AccessTypeOnline)
+}
+
+// Exchange implements Provider.
+func (g *GoogleProvider) Exchange(ctx context.Context, code string) (*UserInfo, error) {
+	ctx = g.ctxWithClient(ctx)
+	token, err := g.cfg.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("google: exchange: %w", err)
+	}
+	return g.fetchUserInfo(ctx, token.AccessToken)
+}
+
+// DeviceAuth implements Provider using Google's device authorisation endpoint.
+func (g *GoogleProvider) DeviceAuth(ctx context.Context) (*DeviceAuthResponse, error) {
+	ctx = g.ctxWithClient(ctx)
+	resp, err := g.cfg.DeviceAuth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("google: device auth: %w", err)
+	}
+	return &DeviceAuthResponse{
+		DeviceCode:      resp.DeviceCode,
+		UserCode:        resp.UserCode,
+		VerificationURI: resp.VerificationURI,
+		ExpiresIn:       int(resp.Expiry.Unix()),
+		Interval:        int(resp.Interval),
+	}, nil
+}
+
+// DevicePoll implements Provider.
+// Returns ErrAuthorizationPending while the user has not yet approved the request.
+func (g *GoogleProvider) DevicePoll(ctx context.Context, deviceCode string) (*UserInfo, error) {
+	ctx = g.ctxWithClient(ctx)
+	deviceResp := &oauth2.DeviceAuthResponse{DeviceCode: deviceCode}
+	token, err := g.cfg.DeviceAccessToken(ctx, deviceResp)
+	if err != nil {
+		return nil, fmt.Errorf("google: device poll: %w: %w", ErrAuthorizationPending, err)
+	}
+	return g.fetchUserInfo(ctx, token.AccessToken)
+}
+
+// fetchUserInfo retrieves the authenticated user's profile from Google's userinfo endpoint.
+func (g *GoogleProvider) fetchUserInfo(ctx context.Context, accessToken string) (*UserInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, googleUserInfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("google: userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("google: userinfo: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("google: read userinfo: %w", err)
+	}
+
+	var info struct {
+		Sub   string `json:"sub"`
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("google: parse userinfo: %w", err)
+	}
+
+	return &UserInfo{
+		ProviderID: info.Sub,
+		Email:      info.Email,
+		Name:       info.Name,
+	}, nil
+}

--- a/internal/infrastructure/oauth2/oauth2.go
+++ b/internal/infrastructure/oauth2/oauth2.go
@@ -1,0 +1,62 @@
+// Package oauth2 provides OAuth2 provider adapters for CourtKnights.
+// Each provider implements the Provider interface for both the redirect
+// (web) flow and the Device Authorization Grant (RFC 8628, CLI) flow.
+package oauth2
+
+import "context"
+
+// UserInfo holds the normalised user data returned by an OAuth2 provider
+// after a successful token exchange.
+type UserInfo struct {
+	// ProviderID is the user's unique identifier within the provider's namespace.
+	ProviderID string
+	// Email is the user's primary email address.
+	Email string
+	// Name is the user's display name.
+	Name string
+}
+
+// DeviceAuthResponse contains the fields returned by the device authorisation endpoint.
+// The user must visit VerificationURI and enter UserCode to grant access.
+type DeviceAuthResponse struct {
+	// DeviceCode is an opaque code used to poll for the token.
+	DeviceCode string
+	// UserCode is the short code shown to the end user.
+	UserCode string
+	// VerificationURI is the URL the user must visit.
+	VerificationURI string
+	// ExpiresIn is the lifetime of the device code in seconds.
+	ExpiresIn int
+	// Interval is the polling interval in seconds.
+	Interval int
+}
+
+// Provider defines the OAuth2 operations required by the AuthService.
+// Implementations must be safe for concurrent use.
+type Provider interface {
+	// AuthCodeURL returns the provider's authorisation URL for the redirect flow.
+	// state is an opaque CSRF token.
+	AuthCodeURL(state string) string
+
+	// Exchange trades an authorisation code for user information.
+	Exchange(ctx context.Context, code string) (*UserInfo, error)
+
+	// DeviceAuth initiates a Device Authorization Grant.
+	// Returns the device auth response containing the user_code and verification_uri.
+	DeviceAuth(ctx context.Context) (*DeviceAuthResponse, error)
+
+	// DevicePoll polls the provider's token endpoint using the device code.
+	// Returns ErrAuthorizationPending when the user has not yet granted access.
+	// Returns UserInfo once the user has approved the request.
+	DevicePoll(ctx context.Context, deviceCode string) (*UserInfo, error)
+}
+
+// ErrAuthorizationPending is returned by DevicePoll when the device code is
+// valid but the user has not yet completed the authorisation.
+var ErrAuthorizationPending = &authorizationPendingError{}
+
+type authorizationPendingError struct{}
+
+func (e *authorizationPendingError) Error() string {
+	return "authorization_pending"
+}

--- a/internal/infrastructure/oauth2/oauth2_test.go
+++ b/internal/infrastructure/oauth2/oauth2_test.go
@@ -1,0 +1,125 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	xoauth2 "golang.org/x/oauth2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// roundTripFunc creates an http.RoundTripper from a function.
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// jsonResp builds an *http.Response with a JSON body.
+func jsonResp(status int, body any) *http.Response {
+	b, _ := json.Marshal(body)
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(status)
+	_, _ = rec.Write(b)
+	return rec.Result()
+}
+
+// tokenTransport returns a RoundTripper that serves tokenPayload for requests
+// whose URL contains "token", and userPayload for all other requests.
+// Since ctxWithClient injects the transport into the oauth2 library, both the
+// token exchange and the userinfo calls go through this transport.
+func tokenTransport(tokenPayload, userPayload any) roundTripFunc {
+	return func(r *http.Request) (*http.Response, error) {
+		if strings.Contains(r.URL.String(), "token") {
+			return jsonResp(http.StatusOK, tokenPayload), nil
+		}
+		return jsonResp(http.StatusOK, userPayload), nil
+	}
+}
+
+// ---- Google ----
+
+func TestGoogleProvider_AuthCodeURL_ContainsGoogleDomain(t *testing.T) {
+	p := NewGoogle(GoogleConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-secret",
+		RedirectURL:  "http://localhost/auth/google/callback",
+	}, nil)
+
+	url := p.AuthCodeURL("state-abc")
+	assert.Contains(t, url, "accounts.google.com")
+	assert.Contains(t, url, "state-abc")
+}
+
+func TestGoogleProvider_Exchange_MapsUserInfo(t *testing.T) {
+	tokenPayload := map[string]any{"access_token": "fake-google-token", "token_type": "Bearer"}
+	userPayload := map[string]string{"sub": "google-123", "email": "alice@example.com", "name": "Alice"}
+
+	p := NewGoogle(GoogleConfig{ClientID: "id", ClientSecret: "secret", RedirectURL: "http://localhost/cb"},
+		&http.Client{Transport: tokenTransport(tokenPayload, userPayload)})
+	// Point token URL at a fake path that contains "token" so our transport routes it correctly.
+	p.cfg.Endpoint = xoauth2.Endpoint{
+		AuthURL:  "https://accounts.google.com/o/oauth2/auth",
+		TokenURL: "http://fake/token",
+	}
+
+	info, err := p.Exchange(context.Background(), "valid-code")
+	require.NoError(t, err)
+	assert.Equal(t, "google-123", info.ProviderID)
+	assert.Equal(t, "alice@example.com", info.Email)
+	assert.Equal(t, "Alice", info.Name)
+}
+
+// ---- GitHub ----
+
+func TestGitHubProvider_AuthCodeURL_ContainsGitHubDomain(t *testing.T) {
+	p := NewGitHub(GitHubConfig{
+		ClientID:     "gh-client-id",
+		ClientSecret: "gh-secret",
+		RedirectURL:  "http://localhost/auth/github/callback",
+	}, nil)
+
+	url := p.AuthCodeURL("state-xyz")
+	assert.Contains(t, url, "github.com")
+	assert.Contains(t, url, "state-xyz")
+}
+
+func TestGitHubProvider_Exchange_MapsUserInfo(t *testing.T) {
+	tokenPayload := map[string]any{"access_token": "gh-token", "token_type": "bearer"}
+	userPayload := map[string]any{"id": int64(42), "login": "bob", "name": "Bob Builder", "email": "bob@example.com"}
+
+	p := NewGitHub(GitHubConfig{ClientID: "id", ClientSecret: "secret"},
+		&http.Client{Transport: tokenTransport(tokenPayload, userPayload)})
+	p.cfg.Endpoint = xoauth2.Endpoint{
+		AuthURL:  "https://github.com/login/oauth/authorize",
+		TokenURL: "http://fake/token",
+	}
+
+	info, err := p.Exchange(context.Background(), "valid-code")
+	require.NoError(t, err)
+	assert.Equal(t, "42", info.ProviderID)
+	assert.Equal(t, "bob@example.com", info.Email)
+	assert.Equal(t, "Bob Builder", info.Name)
+}
+
+func TestGitHubProvider_Exchange_FallbackNameToLogin(t *testing.T) {
+	tokenPayload := map[string]any{"access_token": "gh-token", "token_type": "bearer"}
+	userPayload := map[string]any{"id": int64(7), "login": "charlie", "name": "", "email": "charlie@example.com"}
+
+	p := NewGitHub(GitHubConfig{ClientID: "id", ClientSecret: "secret"},
+		&http.Client{Transport: tokenTransport(tokenPayload, userPayload)})
+	p.cfg.Endpoint = xoauth2.Endpoint{TokenURL: "http://fake/token"}
+
+	info, err := p.Exchange(context.Background(), "code")
+	require.NoError(t, err)
+	// When name is empty, login is used as fallback.
+	assert.Equal(t, "charlie", info.Name)
+}
+
+func TestErrAuthorizationPending_Error(t *testing.T) {
+	assert.Equal(t, "authorization_pending", ErrAuthorizationPending.Error())
+}


### PR DESCRIPTION
## Summary

Implements T-05 from the authentication feature spec.

- `internal/infrastructure/oauth2/oauth2.go` — `Provider` interface (`AuthCodeURL`, `Exchange`, `DeviceAuth`, `DevicePoll`), `UserInfo`, `DeviceAuthResponse`, `ErrAuthorizationPending`
- `internal/infrastructure/oauth2/google.go` — Google OAuth2 implementation; injects `httpClient` via `oauth2.HTTPClient` context key for full testability
- `internal/infrastructure/oauth2/github.go` — GitHub OAuth2 implementation; same testability pattern; falls back to `login` when `name` is empty

Also adds `golang.org/x/oauth2` to `Dependency.md`.

## Test plan

- [x] `TestGoogleProvider_AuthCodeURL_ContainsGoogleDomain`
- [x] `TestGoogleProvider_Exchange_MapsUserInfo` — `sub`, `email`, `name` mapped correctly
- [x] `TestGitHubProvider_AuthCodeURL_ContainsGitHubDomain`
- [x] `TestGitHubProvider_Exchange_MapsUserInfo` — numeric ID → string ProviderID
- [x] `TestGitHubProvider_Exchange_FallbackNameToLogin` — empty `name` falls back to `login`
- [x] `TestErrAuthorizationPending_Error`
- [x] Full `make test` passes

Closes #11
Spec: docs/specs/FEATURE_authentication/03_tasks.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)