### PR TITLE
[CK-11] T-05: Infrastructure — OAuth2 adapters (Google + GitHub)

### DIFF
--- a/Dependency.md
+++ b/Dependency.md
@@ -13,14 +13,13 @@ Format: **Name** | **Purpose** | **License**
 | `github.com/stretchr/testify` | Test assertions and mock framework (`assert`, `require`, `mock`) | MIT |
 | `github.com/golang-jwt/jwt/v5` | JWT signing and validation (HS256) | MIT |
 | `github.com/spf13/viper` | Configuration management — env vars, config files (ADR-002) | MIT |
+| `golang.org/x/oauth2` | OAuth2 client — redirect flow and device flow for Google and GitHub | BSD-3-Clause |
 
 ---
 
 ## To be added (approved in spec)
 
 | Name | Purpose | License | Approved in |
-|------|---------|---------|-------------|
-| `golang.org/x/oauth2` | OAuth2 client — redirect flow and device flow for Google and GitHub | BSD-3-Clause | `docs/specs/FEATURE_authentication/02_architecture.md` |
 | `github.com/labstack/echo/v4` | HTTP API framework (ADR-001) | MIT | `docs/decisions/ADR-001_http-framework-echo.md` |
 | `github.com/spf13/cobra` | CLI framework (ADR-002) | Apache-2.0 | `docs/decisions/ADR-002_cli-cobra-viper.md` |
 | `github.com/jackc/pgx/v5` | PostgreSQL driver (ADR-003) | MIT | `docs/decisions/ADR-003_database-postgresql.md` |

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,17 @@
 module github.com/courtknights/courtknights
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/oauth2 v0.36.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -40,6 +42,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=

--- a/internal/infrastructure/oauth2/github.go
+++ b/internal/infrastructure/oauth2/github.go
@@ -1,0 +1,139 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/github"
+)
+
+const githubUserURL = "https://api.github.com/user"
+
+// GitHubConfig holds the configuration for the GitHub OAuth2 provider.
+type GitHubConfig struct {
+	// ClientID is the GitHub OAuth App client ID.
+	ClientID string
+	// ClientSecret is the GitHub OAuth App client secret.
+	ClientSecret string
+	// RedirectURL is the callback URL registered in the GitHub OAuth App.
+	RedirectURL string
+}
+
+// GitHubProvider implements Provider for GitHub OAuth2.
+type GitHubProvider struct {
+	cfg        *oauth2.Config
+	httpClient *http.Client
+}
+
+// NewGitHub returns a GitHubProvider configured with the given credentials.
+// httpClient is optional; if nil, http.DefaultClient is used.
+func NewGitHub(cfg GitHubConfig, httpClient *http.Client) *GitHubProvider {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &GitHubProvider{
+		cfg: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURL:  cfg.RedirectURL,
+			Scopes:       []string{"read:user", "user:email"},
+			Endpoint:     github.Endpoint,
+		},
+		httpClient: httpClient,
+	}
+}
+
+// ctxWithClient injects httpClient into the context so the oauth2 library uses
+// it for all HTTP calls (token exchange, device auth, etc.).
+func (g *GitHubProvider) ctxWithClient(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, g.httpClient)
+}
+
+// AuthCodeURL implements Provider.
+func (g *GitHubProvider) AuthCodeURL(state string) string {
+	return g.cfg.AuthCodeURL(state, oauth2.AccessTypeOnline)
+}
+
+// Exchange implements Provider.
+func (g *GitHubProvider) Exchange(ctx context.Context, code string) (*UserInfo, error) {
+	ctx = g.ctxWithClient(ctx)
+	token, err := g.cfg.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("github: exchange: %w", err)
+	}
+	return g.fetchUserInfo(ctx, token.AccessToken)
+}
+
+// DeviceAuth implements Provider using GitHub's device authorisation flow.
+func (g *GitHubProvider) DeviceAuth(ctx context.Context) (*DeviceAuthResponse, error) {
+	ctx = g.ctxWithClient(ctx)
+	resp, err := g.cfg.DeviceAuth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("github: device auth: %w", err)
+	}
+	return &DeviceAuthResponse{
+		DeviceCode:      resp.DeviceCode,
+		UserCode:        resp.UserCode,
+		VerificationURI: resp.VerificationURI,
+		ExpiresIn:       int(resp.Expiry.Unix()),
+		Interval:        int(resp.Interval),
+	}, nil
+}
+
+// DevicePoll implements Provider.
+// Returns ErrAuthorizationPending while the user has not yet approved the request.
+func (g *GitHubProvider) DevicePoll(ctx context.Context, deviceCode string) (*UserInfo, error) {
+	ctx = g.ctxWithClient(ctx)
+	deviceResp := &oauth2.DeviceAuthResponse{DeviceCode: deviceCode}
+	token, err := g.cfg.DeviceAccessToken(ctx, deviceResp)
+	if err != nil {
+		return nil, fmt.Errorf("github: device poll: %w: %w", ErrAuthorizationPending, err)
+	}
+	return g.fetchUserInfo(ctx, token.AccessToken)
+}
+
+// fetchUserInfo retrieves the authenticated user's profile from the GitHub API.
+func (g *GitHubProvider) fetchUserInfo(ctx context.Context, accessToken string) (*UserInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubUserURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("github: userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github: userinfo: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("github: read userinfo: %w", err)
+	}
+
+	var info struct {
+		ID    int64  `json:"id"`
+		Login string `json:"login"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("github: parse userinfo: %w", err)
+	}
+
+	name := info.Name
+	if name == "" {
+		name = info.Login
+	}
+
+	return &UserInfo{
+		ProviderID: fmt.Sprintf("%d", info.ID),
+		Email:      info.Email,
+		Name:       name,
+	}, nil
+}

--- a/internal/infrastructure/oauth2/google.go
+++ b/internal/infrastructure/oauth2/google.go
@@ -1,0 +1,132 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const googleUserInfoURL = "https://www.googleapis.com/oauth2/v3/userinfo"
+
+// GoogleConfig holds the configuration for the Google OAuth2 provider.
+type GoogleConfig struct {
+	// ClientID is the Google OAuth2 client ID.
+	ClientID string
+	// ClientSecret is the Google OAuth2 client secret.
+	ClientSecret string
+	// RedirectURL is the callback URL registered in Google Cloud Console.
+	RedirectURL string
+}
+
+// GoogleProvider implements Provider for Google OAuth2.
+type GoogleProvider struct {
+	cfg        *oauth2.Config
+	httpClient *http.Client
+}
+
+// NewGoogle returns a GoogleProvider configured with the given credentials.
+// httpClient is optional; if nil, http.DefaultClient is used.
+func NewGoogle(cfg GoogleConfig, httpClient *http.Client) *GoogleProvider {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &GoogleProvider{
+		cfg: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURL:  cfg.RedirectURL,
+			Scopes:       []string{"openid", "email", "profile"},
+			Endpoint:     google.Endpoint,
+		},
+		httpClient: httpClient,
+	}
+}
+
+// ctxWithClient injects httpClient into the context so the oauth2 library uses
+// it for all HTTP calls (token exchange, device auth, etc.).
+func (g *GoogleProvider) ctxWithClient(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, g.httpClient)
+}
+
+// AuthCodeURL implements Provider.
+func (g *GoogleProvider) AuthCodeURL(state string) string {
+	return g.cfg.AuthCodeURL(state, oauth2.AccessTypeOnline)
+}
+
+// Exchange implements Provider.
+func (g *GoogleProvider) Exchange(ctx context.Context, code string) (*UserInfo, error) {
+	ctx = g.ctxWithClient(ctx)
+	token, err := g.cfg.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("google: exchange: %w", err)
+	}
+	return g.fetchUserInfo(ctx, token.AccessToken)
+}
+
+// DeviceAuth implements Provider using Google's device authorisation endpoint.
+func (g *GoogleProvider) DeviceAuth(ctx context.Context) (*DeviceAuthResponse, error) {
+	ctx = g.ctxWithClient(ctx)
+	resp, err := g.cfg.DeviceAuth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("google: device auth: %w", err)
+	}
+	return &DeviceAuthResponse{
+		DeviceCode:      resp.DeviceCode,
+		UserCode:        resp.UserCode,
+		VerificationURI: resp.VerificationURI,
+		ExpiresIn:       int(resp.Expiry.Unix()),
+		Interval:        int(resp.Interval),
+	}, nil
+}
+
+// DevicePoll implements Provider.
+// Returns ErrAuthorizationPending while the user has not yet approved the request.
+func (g *GoogleProvider) DevicePoll(ctx context.Context, deviceCode string) (*UserInfo, error) {
+	ctx = g.ctxWithClient(ctx)
+	deviceResp := &oauth2.DeviceAuthResponse{DeviceCode: deviceCode}
+	token, err := g.cfg.DeviceAccessToken(ctx, deviceResp)
+	if err != nil {
+		return nil, fmt.Errorf("google: device poll: %w: %w", ErrAuthorizationPending, err)
+	}
+	return g.fetchUserInfo(ctx, token.AccessToken)
+}
+
+// fetchUserInfo retrieves the authenticated user's profile from Google's userinfo endpoint.
+func (g *GoogleProvider) fetchUserInfo(ctx context.Context, accessToken string) (*UserInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, googleUserInfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("google: userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("google: userinfo: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("google: read userinfo: %w", err)
+	}
+
+	var info struct {
+		Sub   string `json:"sub"`
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &info); err != nil {
+		return nil, fmt.Errorf("google: parse userinfo: %w", err)
+	}
+
+	return &UserInfo{
+		ProviderID: info.Sub,
+		Email:      info.Email,
+		Name:       info.Name,
+	}, nil
+}

--- a/internal/infrastructure/oauth2/oauth2.go
+++ b/internal/infrastructure/oauth2/oauth2.go
@@ -1,0 +1,62 @@
+// Package oauth2 provides OAuth2 provider adapters for CourtKnights.
+// Each provider implements the Provider interface for both the redirect
+// (web) flow and the Device Authorization Grant (RFC 8628, CLI) flow.
+package oauth2
+
+import "context"
+
+// UserInfo holds the normalised user data returned by an OAuth2 provider
+// after a successful token exchange.
+type UserInfo struct {
+	// ProviderID is the user's unique identifier within the provider's namespace.
+	ProviderID string
+	// Email is the user's primary email address.
+	Email string
+	// Name is the user's display name.
+	Name string
+}
+
+// DeviceAuthResponse contains the fields returned by the device authorisation endpoint.
+// The user must visit VerificationURI and enter UserCode to grant access.
+type DeviceAuthResponse struct {
+	// DeviceCode is an opaque code used to poll for the token.
+	DeviceCode string
+	// UserCode is the short code shown to the end user.
+	UserCode string
+	// VerificationURI is the URL the user must visit.
+	VerificationURI string
+	// ExpiresIn is the lifetime of the device code in seconds.
+	ExpiresIn int
+	// Interval is the polling interval in seconds.
+	Interval int
+}
+
+// Provider defines the OAuth2 operations required by the AuthService.
+// Implementations must be safe for concurrent use.
+type Provider interface {
+	// AuthCodeURL returns the provider's authorisation URL for the redirect flow.
+	// state is an opaque CSRF token.
+	AuthCodeURL(state string) string
+
+	// Exchange trades an authorisation code for user information.
+	Exchange(ctx context.Context, code string) (*UserInfo, error)
+
+	// DeviceAuth initiates a Device Authorization Grant.
+	// Returns the device auth response containing the user_code and verification_uri.
+	DeviceAuth(ctx context.Context) (*DeviceAuthResponse, error)
+
+	// DevicePoll polls the provider's token endpoint using the device code.
+	// Returns ErrAuthorizationPending when the user has not yet granted access.
+	// Returns UserInfo once the user has approved the request.
+	DevicePoll(ctx context.Context, deviceCode string) (*UserInfo, error)
+}
+
+// ErrAuthorizationPending is returned by DevicePoll when the device code is
+// valid but the user has not yet completed the authorisation.
+var ErrAuthorizationPending = &authorizationPendingError{}
+
+type authorizationPendingError struct{}
+
+func (e *authorizationPendingError) Error() string {
+	return "authorization_pending"
+}

--- a/internal/infrastructure/oauth2/oauth2_test.go
+++ b/internal/infrastructure/oauth2/oauth2_test.go
@@ -1,0 +1,125 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	xoauth2 "golang.org/x/oauth2"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// roundTripFunc creates an http.RoundTripper from a function.
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// jsonResp builds an *http.Response with a JSON body.
+func jsonResp(status int, body any) *http.Response {
+	b, _ := json.Marshal(body)
+	rec := httptest.NewRecorder()
+	rec.WriteHeader(status)
+	_, _ = rec.Write(b)
+	return rec.Result()
+}
+
+// tokenTransport returns a RoundTripper that serves tokenPayload for requests
+// whose URL contains "token", and userPayload for all other requests.
+// Since ctxWithClient injects the transport into the oauth2 library, both the
+// token exchange and the userinfo calls go through this transport.
+func tokenTransport(tokenPayload, userPayload any) roundTripFunc {
+	return func(r *http.Request) (*http.Response, error) {
+		if strings.Contains(r.URL.String(), "token") {
+			return jsonResp(http.StatusOK, tokenPayload), nil
+		}
+		return jsonResp(http.StatusOK, userPayload), nil
+	}
+}
+
+// ---- Google ----
+
+func TestGoogleProvider_AuthCodeURL_ContainsGoogleDomain(t *testing.T) {
+	p := NewGoogle(GoogleConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-secret",
+		RedirectURL:  "http://localhost/auth/google/callback",
+	}, nil)
+
+	url := p.AuthCodeURL("state-abc")
+	assert.Contains(t, url, "accounts.google.com")
+	assert.Contains(t, url, "state-abc")
+}
+
+func TestGoogleProvider_Exchange_MapsUserInfo(t *testing.T) {
+	tokenPayload := map[string]any{"access_token": "fake-google-token", "token_type": "Bearer"}
+	userPayload := map[string]string{"sub": "google-123", "email": "alice@example.com", "name": "Alice"}
+
+	p := NewGoogle(GoogleConfig{ClientID: "id", ClientSecret: "secret", RedirectURL: "http://localhost/cb"},
+		&http.Client{Transport: tokenTransport(tokenPayload, userPayload)})
+	// Point token URL at a fake path that contains "token" so our transport routes it correctly.
+	p.cfg.Endpoint = xoauth2.Endpoint{
+		AuthURL:  "https://accounts.google.com/o/oauth2/auth",
+		TokenURL: "http://fake/token",
+	}
+
+	info, err := p.Exchange(context.Background(), "valid-code")
+	require.NoError(t, err)
+	assert.Equal(t, "google-123", info.ProviderID)
+	assert.Equal(t, "alice@example.com", info.Email)
+	assert.Equal(t, "Alice", info.Name)
+}
+
+// ---- GitHub ----
+
+func TestGitHubProvider_AuthCodeURL_ContainsGitHubDomain(t *testing.T) {
+	p := NewGitHub(GitHubConfig{
+		ClientID:     "gh-client-id",
+		ClientSecret: "gh-secret",
+		RedirectURL:  "http://localhost/auth/github/callback",
+	}, nil)
+
+	url := p.AuthCodeURL("state-xyz")
+	assert.Contains(t, url, "github.com")
+	assert.Contains(t, url, "state-xyz")
+}
+
+func TestGitHubProvider_Exchange_MapsUserInfo(t *testing.T) {
+	tokenPayload := map[string]any{"access_token": "gh-token", "token_type": "bearer"}
+	userPayload := map[string]any{"id": int64(42), "login": "bob", "name": "Bob Builder", "email": "bob@example.com"}
+
+	p := NewGitHub(GitHubConfig{ClientID: "id", ClientSecret: "secret"},
+		&http.Client{Transport: tokenTransport(tokenPayload, userPayload)})
+	p.cfg.Endpoint = xoauth2.Endpoint{
+		AuthURL:  "https://github.com/login/oauth/authorize",
+		TokenURL: "http://fake/token",
+	}
+
+	info, err := p.Exchange(context.Background(), "valid-code")
+	require.NoError(t, err)
+	assert.Equal(t, "42", info.ProviderID)
+	assert.Equal(t, "bob@example.com", info.Email)
+	assert.Equal(t, "Bob Builder", info.Name)
+}
+
+func TestGitHubProvider_Exchange_FallbackNameToLogin(t *testing.T) {
+	tokenPayload := map[string]any{"access_token": "gh-token", "token_type": "bearer"}
+	userPayload := map[string]any{"id": int64(7), "login": "charlie", "name": "", "email": "charlie@example.com"}
+
+	p := NewGitHub(GitHubConfig{ClientID: "id", ClientSecret: "secret"},
+		&http.Client{Transport: tokenTransport(tokenPayload, userPayload)})
+	p.cfg.Endpoint = xoauth2.Endpoint{TokenURL: "http://fake/token"}
+
+	info, err := p.Exchange(context.Background(), "code")
+	require.NoError(t, err)
+	// When name is empty, login is used as fallback.
+	assert.Equal(t, "charlie", info.Name)
+}
+
+func TestErrAuthorizationPending_Error(t *testing.T) {
+	assert.Equal(t, "authorization_pending", ErrAuthorizationPending.Error())
+}


### PR DESCRIPTION
## Summary

Implements T-05 from the authentication feature spec.

- `internal/infrastructure/oauth2/oauth2.go` — `Provider` interface (`AuthCodeURL`, `Exchange`, `DeviceAuth`, `DevicePoll`), `UserInfo`, `DeviceAuthResponse`, `ErrAuthorizationPending`
- `internal/infrastructure/oauth2/google.go` — Google OAuth2 implementation; injects `httpClient` via `oauth2.HTTPClient` context key for full testability
- `internal/infrastructure/oauth2/github.go` — GitHub OAuth2 implementation; falls back to `login` when `name` is empty

## Test plan

- [x] `TestGoogleProvider_AuthCodeURL_ContainsGoogleDomain`
- [x] `TestGoogleProvider_Exchange_MapsUserInfo`
- [x] `TestGitHubProvider_AuthCodeURL_ContainsGitHubDomain`
- [x] `TestGitHubProvider_Exchange_MapsUserInfo`
- [x] `TestGitHubProvider_Exchange_FallbackNameToLogin`
- [x] `TestErrAuthorizationPending_Error`
- [x] Full `make test` passes

Closes #11
Spec: docs/specs/FEATURE_authentication/03_tasks.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)