### PR TITLE
[CK-13] T-07: Application — AuthService, JWTManager, OAuthManager

### DIFF
--- a/internal/application/auth/helpers.go
+++ b/internal/application/auth/helpers.go
@@ -1,0 +1,8 @@
+package auth
+
+import "github.com/google/uuid"
+
+// parseUUID is a convenience wrapper around uuid.Parse.
+func parseUUID(s string) (uuid.UUID, error) {
+	return uuid.Parse(s)
+}

--- a/internal/application/auth/jwt_manager.go
+++ b/internal/application/auth/jwt_manager.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"fmt"
+
+	"github.com/courtknights/courtknights/internal/domain/user"
+	jwtinfra "github.com/courtknights/courtknights/internal/infrastructure/jwt"
+)
+
+// jwtAdapter is the subset of the JWT infrastructure adapter used by JWTManager.
+type jwtAdapter interface {
+	Sign(u *user.User) (string, error)
+	Validate(tokenStr string) (*jwtinfra.Claims, error)
+}
+
+// JWTManager encapsulates all JWT business logic.
+// It is the only application-layer component that talks to the JWT infrastructure adapter.
+type JWTManager struct {
+	adapter jwtAdapter
+}
+
+// NewJWTManager returns a JWTManager backed by the given adapter.
+func NewJWTManager(adapter jwtAdapter) *JWTManager {
+	return &JWTManager{adapter: adapter}
+}
+
+// Sign issues a signed JWT for the given user.
+func (m *JWTManager) Sign(u *user.User) (string, error) {
+	token, err := m.adapter.Sign(u)
+	if err != nil {
+		return "", fmt.Errorf("jwt manager: sign: %w", err)
+	}
+	return token, nil
+}
+
+// Validate parses and verifies a JWT string, returning its claims.
+func (m *JWTManager) Validate(tokenStr string) (*jwtinfra.Claims, error) {
+	claims, err := m.adapter.Validate(tokenStr)
+	if err != nil {
+		return nil, fmt.Errorf("jwt manager: validate: %w", err)
+	}
+	return claims, nil
+}

--- a/internal/application/auth/jwt_manager_test.go
+++ b/internal/application/auth/jwt_manager_test.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/courtknights/courtknights/internal/domain/user"
+	jwtinfra "github.com/courtknights/courtknights/internal/infrastructure/jwt"
+)
+
+func TestJWTManager_Sign_DelegatesToAdapter(t *testing.T) {
+	adapt := &mockJWTAdapter{}
+	u := &user.User{ID: uuid.New(), Email: "alice@example.com", Role: user.RoleUser}
+	adapt.On("Sign", u).Return("signed-token", nil)
+
+	mgr := NewJWTManager(adapt)
+	token, err := mgr.Sign(u)
+	require.NoError(t, err)
+	assert.Equal(t, "signed-token", token)
+	adapt.AssertExpectations(t)
+}
+
+func TestJWTManager_Sign_PropagatesError(t *testing.T) {
+	adapt := &mockJWTAdapter{}
+	u := &user.User{}
+	adapt.On("Sign", u).Return("", errors.New("signing failed"))
+
+	mgr := NewJWTManager(adapt)
+	_, err := mgr.Sign(u)
+	require.Error(t, err)
+}
+
+func TestJWTManager_Validate_DelegatesToAdapter(t *testing.T) {
+	adapt := &mockJWTAdapter{}
+	claims := &jwtinfra.Claims{}
+	claims.Subject = uuid.New().String()
+	adapt.On("Validate", "valid-token").Return(claims, nil)
+
+	mgr := NewJWTManager(adapt)
+	got, err := mgr.Validate("valid-token")
+	require.NoError(t, err)
+	assert.Equal(t, claims.Subject, got.Subject)
+}
+
+func TestJWTManager_Validate_PropagatesError(t *testing.T) {
+	adapt := &mockJWTAdapter{}
+	adapt.On("Validate", "bad-token").Return(nil, errors.New("invalid"))
+
+	mgr := NewJWTManager(adapt)
+	_, err := mgr.Validate("bad-token")
+	require.Error(t, err)
+}

--- a/internal/application/auth/oauth_manager.go
+++ b/internal/application/auth/oauth_manager.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/courtknights/courtknights/internal/domain/user"
+	oauth2infra "github.com/courtknights/courtknights/internal/infrastructure/oauth2"
+)
+
+// ErrProviderNotConfigured is returned when an operation targets an OAuth2
+// provider that has not been registered.
+var ErrProviderNotConfigured = fmt.Errorf("provider not configured")
+
+// OAuthManager encapsulates all OAuth2 business logic.
+// It owns the provider registry and is the only application-layer component
+// that talks to OAuth2 infrastructure adapters.
+type OAuthManager struct {
+	providers map[user.Provider]oauth2infra.Provider
+}
+
+// NewOAuthManager returns an OAuthManager with the given provider registry.
+// Providers absent from the map will cause ErrProviderNotConfigured to be returned.
+func NewOAuthManager(providers map[user.Provider]oauth2infra.Provider) *OAuthManager {
+	return &OAuthManager{providers: providers}
+}
+
+// RedirectURL returns the authorisation URL for the given provider and CSRF state.
+func (m *OAuthManager) RedirectURL(provider user.Provider, state string) (string, error) {
+	p, err := m.provider(provider)
+	if err != nil {
+		return "", err
+	}
+	return p.AuthCodeURL(state), nil
+}
+
+// Exchange trades an authorisation code for normalised user information.
+func (m *OAuthManager) Exchange(ctx context.Context, provider user.Provider, code string) (*oauth2infra.UserInfo, error) {
+	p, err := m.provider(provider)
+	if err != nil {
+		return nil, err
+	}
+	info, err := p.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("oauth manager: exchange: %w", err)
+	}
+	return info, nil
+}
+
+// DeviceAuth initiates the Device Authorization Grant for the given provider.
+func (m *OAuthManager) DeviceAuth(ctx context.Context, provider user.Provider) (*oauth2infra.DeviceAuthResponse, error) {
+	p, err := m.provider(provider)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.DeviceAuth(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("oauth manager: device auth: %w", err)
+	}
+	return resp, nil
+}
+
+// DevicePoll polls the provider's token endpoint using the device code.
+// Returns ErrAuthorizationPending while the user has not yet approved the request.
+func (m *OAuthManager) DevicePoll(ctx context.Context, provider user.Provider, deviceCode string) (*oauth2infra.UserInfo, error) {
+	p, err := m.provider(provider)
+	if err != nil {
+		return nil, err
+	}
+	info, err := p.DevicePoll(ctx, deviceCode)
+	if err != nil {
+		return nil, fmt.Errorf("oauth manager: device poll: %w", err)
+	}
+	return info, nil
+}
+
+// provider looks up the registered adapter for the given provider key.
+func (m *OAuthManager) provider(p user.Provider) (oauth2infra.Provider, error) {
+	prov, ok := m.providers[p]
+	if !ok {
+		return nil, fmt.Errorf("oauth manager: %w: %q", ErrProviderNotConfigured, p)
+	}
+	return prov, nil
+}

--- a/internal/application/auth/oauth_manager_test.go
+++ b/internal/application/auth/oauth_manager_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/courtknights/courtknights/internal/domain/user"
+	oauth2infra "github.com/courtknights/courtknights/internal/infrastructure/oauth2"
+)
+
+func TestOAuthManager_RedirectURL_ReturnsURL(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	prov.On("AuthCodeURL", "state-abc").Return("https://accounts.google.com/auth?state=state-abc")
+
+	mgr := NewOAuthManager(map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov})
+	url, err := mgr.RedirectURL(user.ProviderGoogle, "state-abc")
+	require.NoError(t, err)
+	assert.Contains(t, url, "state-abc")
+}
+
+func TestOAuthManager_RedirectURL_ErrWhenProviderMissing(t *testing.T) {
+	mgr := NewOAuthManager(map[user.Provider]oauth2infra.Provider{})
+	_, err := mgr.RedirectURL(user.ProviderGoogle, "state")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProviderNotConfigured)
+}
+
+func TestOAuthManager_Exchange_ReturnsUserInfo(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	info := &oauth2infra.UserInfo{ProviderID: "g-1", Email: "alice@example.com", Name: "Alice"}
+	prov.On("Exchange", mock.Anything, "code-123").Return(info, nil)
+
+	mgr := NewOAuthManager(map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov})
+	got, err := mgr.Exchange(context.Background(), user.ProviderGoogle, "code-123")
+	require.NoError(t, err)
+	assert.Equal(t, "g-1", got.ProviderID)
+}
+
+func TestOAuthManager_Exchange_PropagatesProviderError(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	prov.On("Exchange", mock.Anything, "bad").Return(nil, errors.New("invalid_grant"))
+
+	mgr := NewOAuthManager(map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov})
+	_, err := mgr.Exchange(context.Background(), user.ProviderGoogle, "bad")
+	require.Error(t, err)
+}
+
+func TestOAuthManager_DeviceAuth_ReturnsResponse(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	resp := &oauth2infra.DeviceAuthResponse{UserCode: "WXYZ-1234", VerificationURI: "https://github.com/login/device"}
+	prov.On("DeviceAuth", mock.Anything).Return(resp, nil)
+
+	mgr := NewOAuthManager(map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov})
+	got, err := mgr.DeviceAuth(context.Background(), user.ProviderGitHub)
+	require.NoError(t, err)
+	assert.Equal(t, "WXYZ-1234", got.UserCode)
+}
+
+func TestOAuthManager_DevicePoll_ReturnsUserInfo(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	info := &oauth2infra.UserInfo{ProviderID: "gh-7", Email: "bob@example.com", Name: "Bob"}
+	prov.On("DevicePoll", mock.Anything, "dev-code").Return(info, nil)
+
+	mgr := NewOAuthManager(map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov})
+	got, err := mgr.DevicePoll(context.Background(), user.ProviderGitHub, "dev-code")
+	require.NoError(t, err)
+	assert.Equal(t, "bob@example.com", got.Email)
+}

--- a/internal/application/auth/service.go
+++ b/internal/application/auth/service.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/courtknights/courtknights/internal/domain/user"
+	oauth2infra "github.com/courtknights/courtknights/internal/infrastructure/oauth2"
+)
+
+// Service is the application-layer orchestrator for authentication flows.
+// It coordinates AuthManager, OAuthManager, and JWTManager.
+// It never calls repositories or infrastructure adapters directly.
+type Service struct {
+	auth  *Manager
+	oauth *OAuthManager
+	jwt   *JWTManager
+}
+
+// NewService returns a Service with the three required managers.
+func NewService(auth *Manager, oauth *OAuthManager, jwt *JWTManager) *Service {
+	return &Service{auth: auth, oauth: oauth, jwt: jwt}
+}
+
+// OAuthRedirectURL returns the provider's authorisation URL for the redirect flow.
+func (s *Service) OAuthRedirectURL(provider user.Provider, state string) (string, error) {
+	return s.oauth.RedirectURL(provider, state)
+}
+
+// OAuthCallback exchanges a provider code for a signed JWT.
+func (s *Service) OAuthCallback(ctx context.Context, provider user.Provider, code string) (string, error) {
+	info, err := s.oauth.Exchange(ctx, provider, code)
+	if err != nil {
+		return "", fmt.Errorf("service: OAuthCallback: %w", err)
+	}
+	u, err := s.auth.ResolveByOAuth(ctx, provider, info.ProviderID, info.Email, info.Name)
+	if err != nil {
+		return "", fmt.Errorf("service: OAuthCallback: %w", err)
+	}
+	return s.jwt.Sign(u)
+}
+
+// DeviceInit initiates the Device Authorization Grant for the given provider.
+func (s *Service) DeviceInit(ctx context.Context, provider user.Provider) (*oauth2infra.DeviceAuthResponse, error) {
+	return s.oauth.DeviceAuth(ctx, provider)
+}
+
+// DevicePoll polls for an authorised device token and returns a signed JWT.
+func (s *Service) DevicePoll(ctx context.Context, provider user.Provider, deviceCode string) (string, error) {
+	info, err := s.oauth.DevicePoll(ctx, provider, deviceCode)
+	if err != nil {
+		return "", fmt.Errorf("service: DevicePoll: %w", err)
+	}
+	u, err := s.auth.ResolveByOAuth(ctx, provider, info.ProviderID, info.Email, info.Name)
+	if err != nil {
+		return "", fmt.Errorf("service: DevicePoll: %w", err)
+	}
+	return s.jwt.Sign(u)
+}
+
+// ExchangePAT validates a raw PAT and returns a signed JWT.
+func (s *Service) ExchangePAT(ctx context.Context, rawPAT string) (string, error) {
+	u, err := s.auth.ResolveByPAT(ctx, rawPAT)
+	if err != nil {
+		return "", fmt.Errorf("service: ExchangePAT: %w", err)
+	}
+	return s.jwt.Sign(u)
+}
+
+// RefreshJWT validates the current JWT and issues a new one with a fresh expiry.
+func (s *Service) RefreshJWT(ctx context.Context, tokenStr string) (string, error) {
+	claims, err := s.jwt.Validate(tokenStr)
+	if err != nil {
+		return "", fmt.Errorf("service: RefreshJWT: %w", err)
+	}
+	u := &user.User{Email: claims.Email, Role: claims.Role}
+	if id, err := parseUUID(claims.Subject); err == nil {
+		u.ID = id
+	}
+	return s.jwt.Sign(u)
+}

--- a/internal/application/auth/service_test.go
+++ b/internal/application/auth/service_test.go
@@ -1,0 +1,281 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/courtknights/courtknights/internal/domain/ckerrors"
+	"github.com/courtknights/courtknights/internal/domain/pat"
+	"github.com/courtknights/courtknights/internal/domain/user"
+	jwtinfra "github.com/courtknights/courtknights/internal/infrastructure/jwt"
+	oauth2infra "github.com/courtknights/courtknights/internal/infrastructure/oauth2"
+)
+
+// ---- mock OAuth2 provider (infrastructure level) ----
+
+type mockOAuth2Provider struct{ mock.Mock }
+
+func (m *mockOAuth2Provider) AuthCodeURL(state string) string {
+	return m.Called(state).String(0)
+}
+func (m *mockOAuth2Provider) Exchange(ctx context.Context, code string) (*oauth2infra.UserInfo, error) {
+	args := m.Called(ctx, code)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*oauth2infra.UserInfo), args.Error(1)
+}
+func (m *mockOAuth2Provider) DeviceAuth(ctx context.Context) (*oauth2infra.DeviceAuthResponse, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*oauth2infra.DeviceAuthResponse), args.Error(1)
+}
+func (m *mockOAuth2Provider) DevicePoll(ctx context.Context, deviceCode string) (*oauth2infra.UserInfo, error) {
+	args := m.Called(ctx, deviceCode)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*oauth2infra.UserInfo), args.Error(1)
+}
+
+// ---- mock JWT adapter (infrastructure level) ----
+
+type mockJWTAdapter struct{ mock.Mock }
+
+func (m *mockJWTAdapter) Sign(u *user.User) (string, error) {
+	args := m.Called(u)
+	return args.String(0), args.Error(1)
+}
+func (m *mockJWTAdapter) Validate(tokenStr string) (*jwtinfra.Claims, error) {
+	args := m.Called(tokenStr)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*jwtinfra.Claims), args.Error(1)
+}
+
+// ---- builder helpers ----
+
+func newTestManagers(
+	userRepo *mockUserRepository,
+	patRepo *mockPATRepository,
+	providers map[user.Provider]oauth2infra.Provider,
+	jwtAdapt *mockJWTAdapter,
+) (*Manager, *OAuthManager, *JWTManager) {
+	return NewManager(userRepo, patRepo),
+		NewOAuthManager(providers),
+		NewJWTManager(jwtAdapt)
+}
+
+func newTestService(
+	userRepo *mockUserRepository,
+	patRepo *mockPATRepository,
+	providers map[user.Provider]oauth2infra.Provider,
+	jwtAdapt *mockJWTAdapter,
+) *Service {
+	auth, oauth, jwt := newTestManagers(userRepo, patRepo, providers, jwtAdapt)
+	return NewService(auth, oauth, jwt)
+}
+
+// ---- OAuthRedirectURL ----
+
+func TestService_OAuthRedirectURL_ReturnsURL(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	prov.On("AuthCodeURL", "state-123").Return("https://accounts.google.com/auth?state=state-123")
+
+	svc := newTestService(
+		&mockUserRepository{}, &mockPATRepository{},
+		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov},
+		&mockJWTAdapter{},
+	)
+
+	url, err := svc.OAuthRedirectURL(user.ProviderGoogle, "state-123")
+	require.NoError(t, err)
+	assert.Contains(t, url, "state-123")
+}
+
+func TestService_OAuthRedirectURL_ErrWhenProviderNotConfigured(t *testing.T) {
+	svc := newTestService(
+		&mockUserRepository{}, &mockPATRepository{},
+		map[user.Provider]oauth2infra.Provider{},
+		&mockJWTAdapter{},
+	)
+
+	_, err := svc.OAuthRedirectURL(user.ProviderGoogle, "state")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProviderNotConfigured)
+}
+
+// ---- OAuthCallback ----
+
+func TestService_OAuthCallback_ValidCode_ReturnsJWT(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	prov := &mockOAuth2Provider{}
+	jwtAdapt := &mockJWTAdapter{}
+
+	resolved := &user.User{ID: uuid.New(), Email: "alice@example.com", Role: user.RoleUser}
+	prov.On("Exchange", mock.Anything, "valid-code").
+		Return(&oauth2infra.UserInfo{ProviderID: "g-1", Email: "alice@example.com", Name: "Alice"}, nil)
+	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).Return(resolved, nil)
+	jwtAdapt.On("Sign", resolved).Return("signed-jwt", nil)
+
+	svc := newTestService(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov},
+		jwtAdapt,
+	)
+
+	token, err := svc.OAuthCallback(context.Background(), user.ProviderGoogle, "valid-code")
+	require.NoError(t, err)
+	assert.Equal(t, "signed-jwt", token)
+}
+
+func TestService_OAuthCallback_InvalidCode_ReturnsError(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	prov.On("Exchange", mock.Anything, "bad-code").Return(nil, errors.New("invalid_grant"))
+
+	svc := newTestService(
+		&mockUserRepository{}, &mockPATRepository{},
+		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov},
+		&mockJWTAdapter{},
+	)
+
+	_, err := svc.OAuthCallback(context.Background(), user.ProviderGoogle, "bad-code")
+	require.Error(t, err)
+}
+
+// ---- DeviceInit ----
+
+func TestService_DeviceInit_ReturnsDeviceAuthResponse(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	expected := &oauth2infra.DeviceAuthResponse{
+		DeviceCode: "dev-code", UserCode: "ABCD-1234", VerificationURI: "https://github.com/login/device",
+	}
+	prov.On("DeviceAuth", mock.Anything).Return(expected, nil)
+
+	svc := newTestService(
+		&mockUserRepository{}, &mockPATRepository{},
+		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov},
+		&mockJWTAdapter{},
+	)
+
+	resp, err := svc.DeviceInit(context.Background(), user.ProviderGitHub)
+	require.NoError(t, err)
+	assert.Equal(t, "ABCD-1234", resp.UserCode)
+}
+
+// ---- DevicePoll ----
+
+func TestService_DevicePoll_Pending_ReturnsErrAuthorizationPending(t *testing.T) {
+	prov := &mockOAuth2Provider{}
+	prov.On("DevicePoll", mock.Anything, "dev-code").
+		Return(nil, fmt.Errorf("poll: %w", oauth2infra.ErrAuthorizationPending))
+
+	svc := newTestService(
+		&mockUserRepository{}, &mockPATRepository{},
+		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov},
+		&mockJWTAdapter{},
+	)
+
+	_, err := svc.DevicePoll(context.Background(), user.ProviderGitHub, "dev-code")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, oauth2infra.ErrAuthorizationPending)
+}
+
+func TestService_DevicePoll_Authorised_ReturnsJWT(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	prov := &mockOAuth2Provider{}
+	jwtAdapt := &mockJWTAdapter{}
+
+	resolved := &user.User{ID: uuid.New(), Email: "bob@example.com", Role: user.RoleUser}
+	prov.On("DevicePoll", mock.Anything, "dev-code").
+		Return(&oauth2infra.UserInfo{ProviderID: "gh-42", Email: "bob@example.com", Name: "Bob"}, nil)
+	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).Return(resolved, nil)
+	jwtAdapt.On("Sign", resolved).Return("device-jwt", nil)
+
+	svc := newTestService(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov},
+		jwtAdapt,
+	)
+
+	token, err := svc.DevicePoll(context.Background(), user.ProviderGitHub, "dev-code")
+	require.NoError(t, err)
+	assert.Equal(t, "device-jwt", token)
+}
+
+// ---- ExchangePAT ----
+
+func TestService_ExchangePAT_ValidPAT_ReturnsJWT(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	jwtAdapt := &mockJWTAdapter{}
+
+	rawKey := "valid-pat-key"
+	salt, _ := generateSalt()
+	hash := hashKey(rawKey, salt)
+	patID := uuid.New()
+	linked := &user.User{ID: uuid.New(), Email: "carol@example.com", Role: user.RoleUser}
+
+	patRepo.On("FindAll", mock.Anything).Return([]*pat.PAT{{ID: patID, KeyHash: hash, Salt: salt}}, nil)
+	userRepo.On("FindByProvider", mock.Anything, user.ProviderPAT, patID.String()).Return(linked, nil)
+	jwtAdapt.On("Sign", linked).Return("pat-jwt", nil)
+
+	svc := newTestService(userRepo, patRepo, map[user.Provider]oauth2infra.Provider{}, jwtAdapt)
+
+	token, err := svc.ExchangePAT(context.Background(), rawKey)
+	require.NoError(t, err)
+	assert.Equal(t, "pat-jwt", token)
+}
+
+func TestService_ExchangePAT_InvalidPAT_ReturnsErrInvalidPAT(t *testing.T) {
+	patRepo := &mockPATRepository{}
+	patRepo.On("FindAll", mock.Anything).Return([]*pat.PAT{}, nil)
+
+	svc := newTestService(&mockUserRepository{}, patRepo, map[user.Provider]oauth2infra.Provider{}, &mockJWTAdapter{})
+
+	_, err := svc.ExchangePAT(context.Background(), "wrong-key")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ckerrors.ErrInvalidPAT)
+}
+
+// ---- RefreshJWT ----
+
+func TestService_RefreshJWT_ValidToken_ReturnsNewJWT(t *testing.T) {
+	jwtAdapt := &mockJWTAdapter{}
+
+	userID := uuid.New()
+	claims := &jwtinfra.Claims{}
+	claims.Subject = userID.String()
+	claims.Email = "dave@example.com"
+	claims.Role = user.RoleUser
+
+	jwtAdapt.On("Validate", "old-token").Return(claims, nil)
+	jwtAdapt.On("Sign", mock.AnythingOfType("*user.User")).Return("new-jwt", nil)
+
+	svc := newTestService(&mockUserRepository{}, &mockPATRepository{}, map[user.Provider]oauth2infra.Provider{}, jwtAdapt)
+
+	token, err := svc.RefreshJWT(context.Background(), "old-token")
+	require.NoError(t, err)
+	assert.Equal(t, "new-jwt", token)
+}
+
+func TestService_RefreshJWT_ExpiredToken_ReturnsErrUnauthorized(t *testing.T) {
+	jwtAdapt := &mockJWTAdapter{}
+	jwtAdapt.On("Validate", "expired-token").Return(nil, fmt.Errorf("%w", ckerrors.ErrUnauthorized))
+
+	svc := newTestService(&mockUserRepository{}, &mockPATRepository{}, map[user.Provider]oauth2infra.Provider{}, jwtAdapt)
+
+	_, err := svc.RefreshJWT(context.Background(), "expired-token")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ckerrors.ErrUnauthorized)
+}


### PR DESCRIPTION
## Summary

Implements T-07 with a corrected three-layer architecture (closes #13).

Replaces the previous approach where `Service` called infrastructure adapters directly.

### New structure

| Component | Responsibility |
|-----------|---------------|
| `AuthManager` | Business logic — resolves users via OAuth2 or PAT, manages PATs, bootstraps admin. Calls repositories only. |
| `JWTManager` | JWT business logic — `Sign` + `Validate`. Only application component that talks to the JWT infrastructure adapter. |
| `OAuthManager` | OAuth2 business logic — provider registry, `RedirectURL`, `Exchange`, `DeviceAuth`, `DevicePoll`. Only component that talks to OAuth2 infrastructure adapters. |
| `AuthService` | **Pure orchestration** — 6 methods, each 2-3 lines. Calls managers only, never touches repositories or adapters directly. |

### Files

- `internal/application/auth/jwt_manager.go` + `jwt_manager_test.go`
- `internal/application/auth/oauth_manager.go` + `oauth_manager_test.go`
- `internal/application/auth/service.go` + `service_test.go`
- `internal/application/auth/helpers.go`

## Test plan

- [x] `JWTManager`: Sign delegates and propagates errors (4 tests)
- [x] `OAuthManager`: RedirectURL, Exchange, DeviceAuth, DevicePoll + missing provider (6 tests)
- [x] `AuthService`: OAuthCallback, DevicePoll, ExchangePAT, RefreshJWT + error paths (11 tests)
- [x] All existing `AuthManager` tests still pass (9 tests)
- [x] Full `make test` passes (30 tests)

Closes #13
Spec: docs/specs/FEATURE_authentication/03_tasks.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)