### PR TITLE
[CK-16] T-10: API — Device Authorization Flow handlers

### DIFF
--- a/internal/api/auth/errors.go
+++ b/internal/api/auth/errors.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	appauth "github.com/courtknights/courtknights/internal/application/auth"
+	oauth2infra "github.com/courtknights/courtknights/internal/infrastructure/oauth2"
 )
 
 // providerError maps application-layer errors to HTTP responses.
@@ -15,4 +16,9 @@ func providerError(err error) error {
 		return echo.NewHTTPError(http.StatusNotImplemented, "provider not configured")
 	}
 	return echo.NewHTTPError(http.StatusInternalServerError, "internal error")
+}
+
+// isAuthorizationPending reports whether err signals the device flow is still waiting.
+func isAuthorizationPending(err error) bool {
+	return errors.Is(err, oauth2infra.ErrAuthorizationPending)
 }

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -63,6 +63,56 @@ func (h *Handler) oauthCallback(c echo.Context) error {
 	return c.Redirect(http.StatusFound, "/?token="+token)
 }
 
+// deviceAuth initiates the Device Authorization Grant for the given provider.
+// POST /auth/device
+func (h *Handler) deviceAuth(c echo.Context) error {
+	var req struct {
+		Provider string `json:"provider"`
+	}
+	if err := c.Bind(&req); err != nil || req.Provider == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "provider is required")
+	}
+
+	provider, err := parseProvider(req.Provider)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	resp, err := h.manager.DeviceInit(c.Request().Context(), provider)
+	if err != nil {
+		return providerError(err)
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+// deviceToken polls for an authorised device token.
+// POST /auth/device/token
+func (h *Handler) deviceToken(c echo.Context) error {
+	var req struct {
+		Provider   string `json:"provider"`
+		DeviceCode string `json:"device_code"`
+	}
+	if err := c.Bind(&req); err != nil || req.Provider == "" || req.DeviceCode == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "provider and device_code are required")
+	}
+
+	provider, err := parseProvider(req.Provider)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	token, err := h.manager.DevicePoll(c.Request().Context(), provider, req.DeviceCode)
+	if err != nil {
+		if isAuthorizationPending(err) {
+			return c.JSON(http.StatusAccepted, map[string]string{"error": "authorization_pending"})
+		}
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication failed")
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"token": token})
+}
+
 // parseProvider converts a path parameter string to a user.Provider.
 func parseProvider(s string) (user.Provider, error) {
 	switch s {

--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -3,8 +3,10 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -195,6 +197,93 @@ func TestOAuthCallback_MissingCode_Returns400(t *testing.T) {
 	c.SetParamValues("google")
 
 	err := h.oauthCallback(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+// ---- POST /auth/device ----
+
+func TestDeviceAuth_ValidProvider_Returns200WithUserCode(t *testing.T) {
+	mgr := &mockAuthManager{}
+	mgr.On("DeviceInit", mock.Anything, user.ProviderGitHub).
+		Return(&oauth2infra.DeviceAuthResponse{
+			DeviceCode: "dev-code", UserCode: "ABCD-1234",
+			VerificationURI: "https://github.com/login/device",
+		}, nil)
+
+	h, e := newTestHandler(mgr)
+	body := `{"provider":"github"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/device", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.deviceAuth(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ABCD-1234")
+}
+
+func TestDeviceAuth_MissingProvider_Returns400(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	req := httptest.NewRequest(http.MethodPost, "/auth/device", strings.NewReader(`{}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.deviceAuth(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+// ---- POST /auth/device/token ----
+
+func TestDeviceToken_Pending_Returns202WithAuthorizationPending(t *testing.T) {
+	mgr := &mockAuthManager{}
+	mgr.On("DevicePoll", mock.Anything, user.ProviderGitHub, "dev-code").
+		Return("", fmt.Errorf("%w", oauth2infra.ErrAuthorizationPending))
+
+	h, e := newTestHandler(mgr)
+	body := `{"provider":"github","device_code":"dev-code"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/device/token", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.deviceToken(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	assert.Contains(t, rec.Body.String(), "authorization_pending")
+}
+
+func TestDeviceToken_Authorised_Returns200WithJWT(t *testing.T) {
+	mgr := &mockAuthManager{}
+	mgr.On("DevicePoll", mock.Anything, user.ProviderGitHub, "dev-code").
+		Return("device-jwt", nil)
+
+	h, e := newTestHandler(mgr)
+	body := `{"provider":"github","device_code":"dev-code"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/device/token", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.deviceToken(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "device-jwt")
+}
+
+func TestDeviceToken_MissingFields_Returns400(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	req := httptest.NewRequest(http.MethodPost, "/auth/device/token", strings.NewReader(`{"provider":"github"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.deviceToken(c)
 	var he *echo.HTTPError
 	require.ErrorAs(t, err, &he)
 	assert.Equal(t, http.StatusBadRequest, he.Code)

--- a/internal/api/auth/routes.go
+++ b/internal/api/auth/routes.go
@@ -17,4 +17,6 @@ func NewRoutes(h *Handler) *Routes {
 func (r *Routes) Register(g *echo.Group) {
 	g.GET("/:provider", r.handler.redirectToProvider)
 	g.GET("/:provider/callback", r.handler.oauthCallback)
+	g.POST("/device", r.handler.deviceAuth)
+	g.POST("/device/token", r.handler.deviceToken)
 }


### PR DESCRIPTION
## Summary

Implements T-10 from the authentication feature spec.

- `POST /auth/device` — initiates Device Auth Grant; requires `provider` in JSON body; returns `200` with `user_code`, `verification_uri`, `device_code`
- `POST /auth/device/token` — polls for token; returns `202` with `authorization_pending` while waiting, `200` with JWT once authorised, `401` on failure
- `ErrProviderNotConfigured` → `501`; `ErrAuthorizationPending` detected via `errors.Is`

## Test plan

- [x] `POST /auth/device` valid provider → `200` with `user_code`
- [x] `POST /auth/device` missing provider → `400`
- [x] `POST /auth/device/token` pending → `202` with `authorization_pending`
- [x] `POST /auth/device/token` authorised → `200` with JWT
- [x] `POST /auth/device/token` missing fields → `400`
- [x] Full `make test` passes (12 handler tests total)

Closes #16
Spec: docs/specs/FEATURE_authentication/03_tasks.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)