### PR TITLE
[CK-17] T-11: PAT exchange and JWT refresh handlers

### DIFF
--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -113,6 +113,42 @@ func (h *Handler) deviceToken(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"token": token})
 }
 
+// exchangePAT trades a raw PAT for a signed JWT.
+// POST /auth/token/pat
+func (h *Handler) exchangePAT(c echo.Context) error {
+	var req struct {
+		Token string `json:"token"`
+	}
+	if err := c.Bind(&req); err != nil || req.Token == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "token is required")
+	}
+
+	jwt, err := h.manager.ExchangePAT(c.Request().Context(), req.Token)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid token")
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"token": jwt})
+}
+
+// refreshJWT validates the current JWT and issues a new one with a fresh expiry.
+// POST /auth/refresh
+func (h *Handler) refreshJWT(c echo.Context) error {
+	var req struct {
+		Token string `json:"token"`
+	}
+	if err := c.Bind(&req); err != nil || req.Token == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "token is required")
+	}
+
+	newToken, err := h.manager.RefreshJWT(c.Request().Context(), req.Token)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired token")
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"token": newToken})
+}
+
 // parseProvider converts a path parameter string to a user.Provider.
 func parseProvider(s string) (user.Provider, error) {
 	switch s {

--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -288,3 +288,105 @@ func TestDeviceToken_MissingFields_Returns400(t *testing.T) {
 	require.ErrorAs(t, err, &he)
 	assert.Equal(t, http.StatusBadRequest, he.Code)
 }
+
+// ---- POST /auth/token/pat ----
+
+func TestExchangePAT_ValidToken_Returns200WithJWT(t *testing.T) {
+	mgr := &mockAuthManager{}
+	mgr.On("ExchangePAT", mock.Anything, "raw-pat-token").
+		Return("signed-jwt", nil)
+
+	h, e := newTestHandler(mgr)
+	body := `{"token":"raw-pat-token"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/token/pat", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.exchangePAT(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "signed-jwt")
+}
+
+func TestExchangePAT_InvalidToken_Returns401(t *testing.T) {
+	mgr := &mockAuthManager{}
+	mgr.On("ExchangePAT", mock.Anything, "bad-pat").
+		Return("", errors.New("invalid token"))
+
+	h, e := newTestHandler(mgr)
+	body := `{"token":"bad-pat"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/token/pat", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.exchangePAT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+func TestExchangePAT_MissingToken_Returns400(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	req := httptest.NewRequest(http.MethodPost, "/auth/token/pat", strings.NewReader(`{}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.exchangePAT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+// ---- POST /auth/refresh ----
+
+func TestRefreshJWT_ValidToken_Returns200WithNewJWT(t *testing.T) {
+	mgr := &mockAuthManager{}
+	mgr.On("RefreshJWT", mock.Anything, "old-jwt").
+		Return("new-jwt", nil)
+
+	h, e := newTestHandler(mgr)
+	body := `{"token":"old-jwt"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.refreshJWT(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "new-jwt")
+}
+
+func TestRefreshJWT_ExpiredToken_Returns401(t *testing.T) {
+	mgr := &mockAuthManager{}
+	mgr.On("RefreshJWT", mock.Anything, "expired-jwt").
+		Return("", errors.New("token expired"))
+
+	h, e := newTestHandler(mgr)
+	body := `{"token":"expired-jwt"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.refreshJWT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+func TestRefreshJWT_MissingToken_Returns400(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", strings.NewReader(`{}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.refreshJWT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+}

--- a/internal/api/auth/routes.go
+++ b/internal/api/auth/routes.go
@@ -19,4 +19,6 @@ func (r *Routes) Register(g *echo.Group) {
 	g.GET("/:provider/callback", r.handler.oauthCallback)
 	g.POST("/device", r.handler.deviceAuth)
 	g.POST("/device/token", r.handler.deviceToken)
+	g.POST("/token/pat", r.handler.exchangePAT)
+	g.POST("/refresh", r.handler.refreshJWT)
 }


### PR DESCRIPTION
## Summary

- Adds `POST /auth/token/pat` — trades a raw PAT for a signed JWT (`exchangePAT` handler)
- Adds `POST /auth/refresh` — validates the current JWT and issues a new one (`refreshJWT` handler)
- Registers both routes on the public `/auth` group (no JWT middleware required)
- Unit tests cover: valid token → 200, invalid/expired token → 401, missing token → 400

## Test plan

- [x] `TestExchangePAT_ValidToken_Returns200WithJWT`
- [x] `TestExchangePAT_InvalidToken_Returns401`
- [x] `TestExchangePAT_MissingToken_Returns400`
- [x] `TestRefreshJWT_ValidToken_Returns200WithNewJWT`
- [x] `TestRefreshJWT_ExpiredToken_Returns401`
- [x] `TestRefreshJWT_MissingToken_Returns400`
- [x] Full regression suite passes (`make test`)

Closes #17
Spec: docs/specs/FEATURE_authentication/03_tasks.md (T-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)