### PR TITLE
[CK-18] T-12: PAT management endpoints

### DIFF
--- a/internal/api/common/middleware.go
+++ b/internal/api/common/middleware.go
@@ -18,6 +18,12 @@ const (
 	ContextKeyRole  = "role"
 )
 
+// IsAdmin reports whether the authenticated user in the context has the admin role.
+func IsAdmin(c echo.Context) bool {
+	role, _ := c.Get(ContextKeyRole).(string)
+	return role == "admin"
+}
+
 // JWTMiddleware returns an Echo middleware that validates the Bearer JWT and
 // sets sub, email, and role on the context. Returns 401 on any failure.
 func JWTMiddleware(jwt auth.JWTManager) echo.MiddlewareFunc {

--- a/internal/api/pats/handler.go
+++ b/internal/api/pats/handler.go
@@ -1,0 +1,90 @@
+// Package pats provides the HTTP handlers for PAT management endpoints.
+package pats
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/courtknights/courtknights/internal/api/common"
+	appauth "github.com/courtknights/courtknights/internal/application/auth"
+)
+
+// Handler handles all PAT management HTTP requests.
+type Handler struct {
+	manager appauth.AuthManager
+}
+
+// NewHandler returns a Handler backed by the given AuthManager.
+func NewHandler(manager appauth.AuthManager) *Handler {
+	return &Handler{manager: manager}
+}
+
+// createPAT creates a new PAT for a given user. Admin only.
+// POST /api/v1/pats
+func (h *Handler) createPAT(c echo.Context) error {
+	if !common.IsAdmin(c) {
+		return echo.NewHTTPError(http.StatusForbidden, "admin role required")
+	}
+
+	var req struct {
+		UserID    string  `json:"user_id"`
+		ExpiresAt *string `json:"expires_at"`
+	}
+	if err := c.Bind(&req); err != nil || req.UserID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "user_id is required")
+	}
+
+	userID, err := uuid.Parse(req.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid user_id")
+	}
+
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil {
+		t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid expires_at format, use RFC3339")
+		}
+		expiresAt = &t
+	}
+
+	rawKey, err := h.manager.CreatePAT(c.Request().Context(), userID, expiresAt)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to create PAT")
+	}
+
+	return c.JSON(http.StatusCreated, map[string]string{"token": rawKey})
+}
+
+// listPATs returns all PATs. Authenticated users only.
+// GET /api/v1/pats
+func (h *Handler) listPATs(c echo.Context) error {
+	pats, err := h.manager.ListPATs(c.Request().Context())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to list PATs")
+	}
+
+	return c.JSON(http.StatusOK, pats)
+}
+
+// revokePAT deletes a PAT by ID. Admin only.
+// DELETE /api/v1/pats/:id
+func (h *Handler) revokePAT(c echo.Context) error {
+	if !common.IsAdmin(c) {
+		return echo.NewHTTPError(http.StatusForbidden, "admin role required")
+	}
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid PAT id")
+	}
+
+	if err := h.manager.RevokePAT(c.Request().Context(), id); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to revoke PAT")
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/internal/api/pats/handler_test.go
+++ b/internal/api/pats/handler_test.go
@@ -1,0 +1,233 @@
+package pats
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/courtknights/courtknights/internal/api/common"
+	appauth "github.com/courtknights/courtknights/internal/application/auth"
+	"github.com/courtknights/courtknights/internal/domain/pat"
+	"github.com/courtknights/courtknights/internal/domain/user"
+	oauth2infra "github.com/courtknights/courtknights/internal/infrastructure/oauth2"
+)
+
+// ---- mock AuthManager ----
+
+type mockAuthManager struct{ mock.Mock }
+
+func (m *mockAuthManager) OAuthRedirectURL(provider user.Provider, state string) (string, error) {
+	args := m.Called(provider, state)
+	return args.String(0), args.Error(1)
+}
+func (m *mockAuthManager) OAuthCallback(ctx context.Context, provider user.Provider, code string) (string, error) {
+	args := m.Called(ctx, provider, code)
+	return args.String(0), args.Error(1)
+}
+func (m *mockAuthManager) DeviceInit(ctx context.Context, provider user.Provider) (*oauth2infra.DeviceAuthResponse, error) {
+	args := m.Called(ctx, provider)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*oauth2infra.DeviceAuthResponse), args.Error(1)
+}
+func (m *mockAuthManager) DevicePoll(ctx context.Context, provider user.Provider, deviceCode string) (string, error) {
+	args := m.Called(ctx, provider, deviceCode)
+	return args.String(0), args.Error(1)
+}
+func (m *mockAuthManager) ExchangePAT(ctx context.Context, rawPAT string) (string, error) {
+	args := m.Called(ctx, rawPAT)
+	return args.String(0), args.Error(1)
+}
+func (m *mockAuthManager) RefreshJWT(ctx context.Context, tokenStr string) (string, error) {
+	args := m.Called(ctx, tokenStr)
+	return args.String(0), args.Error(1)
+}
+func (m *mockAuthManager) CreatePAT(ctx context.Context, userID uuid.UUID, expiresAt *time.Time) (string, error) {
+	args := m.Called(ctx, userID, expiresAt)
+	return args.String(0), args.Error(1)
+}
+func (m *mockAuthManager) RevokePAT(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+func (m *mockAuthManager) ListPATs(ctx context.Context) ([]*pat.PAT, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*pat.PAT), args.Error(1)
+}
+func (m *mockAuthManager) BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error) {
+	args := m.Called(ctx, email, name, rawPAT)
+	return args.String(0), args.Error(1)
+}
+
+// compile-time check
+var _ appauth.AuthManager = (*mockAuthManager)(nil)
+
+// ---- helpers ----
+
+func newTestHandler(mgr appauth.AuthManager) (*Handler, *echo.Echo) {
+	return NewHandler(mgr), echo.New()
+}
+
+func contextWithRole(e *echo.Echo, method, path string, body string, role string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(common.ContextKeyRole, string(role))
+	return c, rec
+}
+
+// ---- POST /api/v1/pats ----
+
+func TestCreatePAT_AsAdmin_Returns201WithToken(t *testing.T) {
+	userID := uuid.New()
+	mgr := &mockAuthManager{}
+	mgr.On("CreatePAT", mock.Anything, userID, (*time.Time)(nil)).
+		Return("raw-pat-key", nil)
+
+	h, e := newTestHandler(mgr)
+	body := `{"user_id":"` + userID.String() + `"}`
+	c, rec := contextWithRole(e, http.MethodPost, "/api/v1/pats", body, string(user.RoleAdmin))
+
+	err := h.createPAT(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.Contains(t, rec.Body.String(), "raw-pat-key")
+}
+
+func TestCreatePAT_AsNonAdmin_Returns403(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	body := `{"user_id":"` + uuid.New().String() + `"}`
+	c, rec := contextWithRole(e, http.MethodPost, "/api/v1/pats", body, string(user.RoleUser))
+
+	err := h.createPAT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusForbidden, he.Code)
+	_ = rec
+}
+
+func TestCreatePAT_MissingUserID_Returns400(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	c, rec := contextWithRole(e, http.MethodPost, "/api/v1/pats", `{}`, string(user.RoleAdmin))
+
+	err := h.createPAT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	_ = rec
+}
+
+func TestCreatePAT_InvalidUserID_Returns400(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	c, rec := contextWithRole(e, http.MethodPost, "/api/v1/pats", `{"user_id":"not-a-uuid"}`, string(user.RoleAdmin))
+
+	err := h.createPAT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	_ = rec
+}
+
+// ---- GET /api/v1/pats ----
+
+func TestListPATs_Returns200WithPATList(t *testing.T) {
+	now := time.Now()
+	pats := []*pat.PAT{
+		{ID: uuid.New(), KeyHash: "hash1", Salt: "salt1", CreatedAt: now},
+	}
+	mgr := &mockAuthManager{}
+	mgr.On("ListPATs", mock.Anything).Return(pats, nil)
+
+	h, e := newTestHandler(mgr)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pats", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(common.ContextKeyRole, string(user.RoleUser))
+
+	err := h.listPATs(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestListPATs_ManagerError_Returns500(t *testing.T) {
+	mgr := &mockAuthManager{}
+	mgr.On("ListPATs", mock.Anything).Return(nil, errors.New("db error"))
+
+	h, e := newTestHandler(mgr)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pats", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.listPATs(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusInternalServerError, he.Code)
+	_ = rec
+}
+
+// ---- DELETE /api/v1/pats/:id ----
+
+func TestRevokePAT_AsAdmin_Returns204(t *testing.T) {
+	patID := uuid.New()
+	mgr := &mockAuthManager{}
+	mgr.On("RevokePAT", mock.Anything, patID).Return(nil)
+
+	h, e := newTestHandler(mgr)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/pats/"+patID.String(), nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(patID.String())
+	c.Set(common.ContextKeyRole, string(user.RoleAdmin))
+
+	err := h.revokePAT(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestRevokePAT_AsNonAdmin_Returns403(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	patID := uuid.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/pats/"+patID.String(), nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(patID.String())
+	c.Set(common.ContextKeyRole, string(user.RoleUser))
+
+	err := h.revokePAT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusForbidden, he.Code)
+	_ = rec
+}
+
+func TestRevokePAT_InvalidID_Returns400(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/pats/bad-id", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("bad-id")
+	c.Set(common.ContextKeyRole, string(user.RoleAdmin))
+
+	err := h.revokePAT(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	_ = rec
+}

--- a/internal/api/pats/routes.go
+++ b/internal/api/pats/routes.go
@@ -1,0 +1,21 @@
+package pats
+
+import "github.com/labstack/echo/v4"
+
+// Routes implements api.RouteRegistrar for the pats feature.
+type Routes struct {
+	handler *Handler
+}
+
+// NewRoutes returns a Routes for the given Handler.
+func NewRoutes(h *Handler) *Routes {
+	return &Routes{handler: h}
+}
+
+// Register mounts all PAT management routes on the given group.
+// Called by the router for the protected /api/v1 prefix (JWT middleware applied).
+func (r *Routes) Register(g *echo.Group) {
+	g.POST("/pats", r.handler.createPAT)
+	g.GET("/pats", r.handler.listPATs)
+	g.DELETE("/pats/:id", r.handler.revokePAT)
+}


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/pats` — admin-only, creates a PAT for a given user; returns `201` with the raw token (shown once)
- Adds `GET /api/v1/pats` — lists all PATs for any authenticated user; returns `200`
- Adds `DELETE /api/v1/pats/:id` — admin-only, revokes a PAT by UUID; returns `204`
- Role enforcement via `common.ContextKeyRole` set by JWT middleware

## Test plan

- [x] `TestCreatePAT_AsAdmin_Returns201WithToken`
- [x] `TestCreatePAT_AsNonAdmin_Returns403`
- [x] `TestCreatePAT_MissingUserID_Returns400`
- [x] `TestCreatePAT_InvalidUserID_Returns400`
- [x] `TestListPATs_Returns200WithPATList`
- [x] `TestListPATs_ManagerError_Returns500`
- [x] `TestRevokePAT_AsAdmin_Returns204`
- [x] `TestRevokePAT_AsNonAdmin_Returns403`
- [x] `TestRevokePAT_InvalidID_Returns400`
- [x] Full regression suite passes (`make test`)

Closes #18
Spec: docs/specs/FEATURE_authentication/03_tasks.md (T-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)