### PR TITLE
[CK-19] T-13: User management endpoints

### DIFF
--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -67,6 +67,9 @@ func (m *mockAuthManager) ListPATs(ctx context.Context) ([]*pat.PAT, error) {
 	}
 	return args.Get(0).([]*pat.PAT), args.Error(1)
 }
+func (m *mockAuthManager) UpdateUserRole(ctx context.Context, userID uuid.UUID, role user.Role) error {
+	return m.Called(ctx, userID, role).Error(0)
+}
 func (m *mockAuthManager) BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error) {
 	args := m.Called(ctx, email, name, rawPAT)
 	return args.String(0), args.Error(1)

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -1,0 +1,64 @@
+// Package users provides the HTTP handlers for user management endpoints.
+package users
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/courtknights/courtknights/internal/api/common"
+	appauth "github.com/courtknights/courtknights/internal/application/auth"
+	"github.com/courtknights/courtknights/internal/domain/user"
+)
+
+// Handler handles all user management HTTP requests.
+type Handler struct {
+	manager appauth.AuthManager
+}
+
+// NewHandler returns a Handler backed by the given AuthManager.
+func NewHandler(manager appauth.AuthManager) *Handler {
+	return &Handler{manager: manager}
+}
+
+// me returns the authenticated user's profile from the JWT context.
+// GET /api/v1/users/me
+func (h *Handler) me(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{
+		"id":    c.Get(common.ContextKeySub).(string),
+		"email": c.Get(common.ContextKeyEmail).(string),
+		"role":  c.Get(common.ContextKeyRole).(string),
+	})
+}
+
+// updateRole sets the role for a user by ID. Admin only.
+// PUT /api/v1/users/:id/role
+func (h *Handler) updateRole(c echo.Context) error {
+	if !common.IsAdmin(c) {
+		return echo.NewHTTPError(http.StatusForbidden, "admin role required")
+	}
+
+	userID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid user id")
+	}
+
+	var req struct {
+		Role string `json:"role"`
+	}
+	if err := c.Bind(&req); err != nil || req.Role == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "role is required")
+	}
+
+	role := user.Role(req.Role)
+	if role != user.RoleAdmin && role != user.RoleUser {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid role, must be 'admin' or 'user'")
+	}
+
+	if err := h.manager.UpdateUserRole(c.Request().Context(), userID, role); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update role")
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"id": userID.String(), "role": string(role)})
+}

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1,4 +1,4 @@
-package pats
+package users
 
 import (
 	"context"
@@ -84,153 +84,106 @@ func newTestHandler(mgr appauth.AuthManager) (*Handler, *echo.Echo) {
 	return NewHandler(mgr), echo.New()
 }
 
-func contextWithRole(e *echo.Echo, method, path string, body string, role string) (echo.Context, *httptest.ResponseRecorder) {
+func contextWithAuth(e *echo.Echo, method, path, body, role, sub, email string) (echo.Context, *httptest.ResponseRecorder) {
 	req := httptest.NewRequest(method, path, strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set(common.ContextKeyRole, string(role))
+	c.Set(common.ContextKeyRole, role)
+	c.Set(common.ContextKeySub, sub)
+	c.Set(common.ContextKeyEmail, email)
 	return c, rec
 }
 
-// ---- POST /api/v1/pats ----
+// ---- GET /api/v1/users/me ----
 
-func TestCreatePAT_AsAdmin_Returns201WithToken(t *testing.T) {
-	userID := uuid.New()
-	mgr := &mockAuthManager{}
-	mgr.On("CreatePAT", mock.Anything, userID, (*time.Time)(nil)).
-		Return("raw-pat-key", nil)
+func TestMe_Returns200WithUserProfile(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	userID := uuid.New().String()
+	c, rec := contextWithAuth(e, http.MethodGet, "/api/v1/users/me", "", string(user.RoleUser), userID, "alice@example.com")
 
-	h, e := newTestHandler(mgr)
-	body := `{"user_id":"` + userID.String() + `"}`
-	c, rec := contextWithRole(e, http.MethodPost, "/api/v1/pats", body, string(user.RoleAdmin))
-
-	err := h.createPAT(c)
+	err := h.me(c)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusCreated, rec.Code)
-	assert.Contains(t, rec.Body.String(), "raw-pat-key")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), userID)
+	assert.Contains(t, rec.Body.String(), "alice@example.com")
+	assert.Contains(t, rec.Body.String(), string(user.RoleUser))
 }
 
-func TestCreatePAT_AsNonAdmin_Returns403(t *testing.T) {
-	h, e := newTestHandler(&mockAuthManager{})
-	body := `{"user_id":"` + uuid.New().String() + `"}`
-	c, rec := contextWithRole(e, http.MethodPost, "/api/v1/pats", body, string(user.RoleUser))
+// ---- PUT /api/v1/users/:id/role ----
 
-	err := h.createPAT(c)
+func TestUpdateRole_AsAdmin_Returns200(t *testing.T) {
+	targetID := uuid.New()
+	mgr := &mockAuthManager{}
+	mgr.On("UpdateUserRole", mock.Anything, targetID, user.RoleUser).Return(nil)
+
+	h, e := newTestHandler(mgr)
+	body := `{"role":"user"}`
+	c, rec := contextWithAuth(e, http.MethodPut, "/api/v1/users/"+targetID.String()+"/role", body, string(user.RoleAdmin), uuid.New().String(), "admin@example.com")
+	c.SetParamNames("id")
+	c.SetParamValues(targetID.String())
+
+	err := h.updateRole(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), targetID.String())
+}
+
+func TestUpdateRole_AsNonAdmin_Returns403(t *testing.T) {
+	h, e := newTestHandler(&mockAuthManager{})
+	targetID := uuid.New()
+	c, rec := contextWithAuth(e, http.MethodPut, "/api/v1/users/"+targetID.String()+"/role", `{"role":"admin"}`, string(user.RoleUser), uuid.New().String(), "user@example.com")
+	c.SetParamNames("id")
+	c.SetParamValues(targetID.String())
+
+	err := h.updateRole(c)
 	var he *echo.HTTPError
 	require.ErrorAs(t, err, &he)
 	assert.Equal(t, http.StatusForbidden, he.Code)
 	_ = rec
 }
 
-func TestCreatePAT_MissingUserID_Returns400(t *testing.T) {
+func TestUpdateRole_InvalidID_Returns400(t *testing.T) {
 	h, e := newTestHandler(&mockAuthManager{})
-	c, rec := contextWithRole(e, http.MethodPost, "/api/v1/pats", `{}`, string(user.RoleAdmin))
+	c, rec := contextWithAuth(e, http.MethodPut, "/api/v1/users/bad-id/role", `{"role":"user"}`, string(user.RoleAdmin), uuid.New().String(), "admin@example.com")
+	c.SetParamNames("id")
+	c.SetParamValues("bad-id")
 
-	err := h.createPAT(c)
+	err := h.updateRole(c)
 	var he *echo.HTTPError
 	require.ErrorAs(t, err, &he)
 	assert.Equal(t, http.StatusBadRequest, he.Code)
 	_ = rec
 }
 
-func TestCreatePAT_InvalidUserID_Returns400(t *testing.T) {
+func TestUpdateRole_InvalidRole_Returns400(t *testing.T) {
 	h, e := newTestHandler(&mockAuthManager{})
-	c, rec := contextWithRole(e, http.MethodPost, "/api/v1/pats", `{"user_id":"not-a-uuid"}`, string(user.RoleAdmin))
+	targetID := uuid.New()
+	c, rec := contextWithAuth(e, http.MethodPut, "/api/v1/users/"+targetID.String()+"/role", `{"role":"superuser"}`, string(user.RoleAdmin), uuid.New().String(), "admin@example.com")
+	c.SetParamNames("id")
+	c.SetParamValues(targetID.String())
 
-	err := h.createPAT(c)
+	err := h.updateRole(c)
 	var he *echo.HTTPError
 	require.ErrorAs(t, err, &he)
 	assert.Equal(t, http.StatusBadRequest, he.Code)
 	_ = rec
 }
 
-// ---- GET /api/v1/pats ----
-
-func TestListPATs_Returns200WithPATList(t *testing.T) {
-	now := time.Now()
-	pats := []*pat.PAT{
-		{ID: uuid.New(), KeyHash: "hash1", Salt: "salt1", CreatedAt: now},
-	}
+func TestUpdateRole_ManagerError_Returns500(t *testing.T) {
+	targetID := uuid.New()
 	mgr := &mockAuthManager{}
-	mgr.On("ListPATs", mock.Anything).Return(pats, nil)
+	mgr.On("UpdateUserRole", mock.Anything, targetID, user.RoleUser).Return(errors.New("db error"))
 
 	h, e := newTestHandler(mgr)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/pats", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set(common.ContextKeyRole, string(user.RoleUser))
+	body := `{"role":"user"}`
+	c, rec := contextWithAuth(e, http.MethodPut, "/api/v1/users/"+targetID.String()+"/role", body, string(user.RoleAdmin), uuid.New().String(), "admin@example.com")
+	c.SetParamNames("id")
+	c.SetParamValues(targetID.String())
 
-	err := h.listPATs(c)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rec.Code)
-}
-
-func TestListPATs_ManagerError_Returns500(t *testing.T) {
-	mgr := &mockAuthManager{}
-	mgr.On("ListPATs", mock.Anything).Return(nil, errors.New("db error"))
-
-	h, e := newTestHandler(mgr)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/pats", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-
-	err := h.listPATs(c)
+	err := h.updateRole(c)
 	var he *echo.HTTPError
 	require.ErrorAs(t, err, &he)
 	assert.Equal(t, http.StatusInternalServerError, he.Code)
-	_ = rec
-}
-
-// ---- DELETE /api/v1/pats/:id ----
-
-func TestRevokePAT_AsAdmin_Returns204(t *testing.T) {
-	patID := uuid.New()
-	mgr := &mockAuthManager{}
-	mgr.On("RevokePAT", mock.Anything, patID).Return(nil)
-
-	h, e := newTestHandler(mgr)
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/pats/"+patID.String(), nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetParamNames("id")
-	c.SetParamValues(patID.String())
-	c.Set(common.ContextKeyRole, string(user.RoleAdmin))
-
-	err := h.revokePAT(c)
-	require.NoError(t, err)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-}
-
-func TestRevokePAT_AsNonAdmin_Returns403(t *testing.T) {
-	h, e := newTestHandler(&mockAuthManager{})
-	patID := uuid.New()
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/pats/"+patID.String(), nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetParamNames("id")
-	c.SetParamValues(patID.String())
-	c.Set(common.ContextKeyRole, string(user.RoleUser))
-
-	err := h.revokePAT(c)
-	var he *echo.HTTPError
-	require.ErrorAs(t, err, &he)
-	assert.Equal(t, http.StatusForbidden, he.Code)
-	_ = rec
-}
-
-func TestRevokePAT_InvalidID_Returns400(t *testing.T) {
-	h, e := newTestHandler(&mockAuthManager{})
-	req := httptest.NewRequest(http.MethodDelete, "/api/v1/pats/bad-id", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetParamNames("id")
-	c.SetParamValues("bad-id")
-	c.Set(common.ContextKeyRole, string(user.RoleAdmin))
-
-	err := h.revokePAT(c)
-	var he *echo.HTTPError
-	require.ErrorAs(t, err, &he)
-	assert.Equal(t, http.StatusBadRequest, he.Code)
 	_ = rec
 }

--- a/internal/api/users/routes.go
+++ b/internal/api/users/routes.go
@@ -1,0 +1,20 @@
+package users
+
+import "github.com/labstack/echo/v4"
+
+// Routes implements api.RouteRegistrar for the users feature.
+type Routes struct {
+	handler *Handler
+}
+
+// NewRoutes returns a Routes for the given Handler.
+func NewRoutes(h *Handler) *Routes {
+	return &Routes{handler: h}
+}
+
+// Register mounts all user management routes on the given group.
+// Called by the router for the protected /api/v1 prefix (JWT middleware applied).
+func (r *Routes) Register(g *echo.Group) {
+	g.GET("/users/me", r.handler.me)
+	g.PUT("/users/:id/role", r.handler.updateRole)
+}

--- a/internal/application/auth/manager.go
+++ b/internal/application/auth/manager.go
@@ -36,6 +36,9 @@ type AuthManager interface {
 	RevokePAT(ctx context.Context, id uuid.UUID) error
 	ListPATs(ctx context.Context) ([]*pat.PAT, error)
 
+	// User management
+	UpdateUserRole(ctx context.Context, userID uuid.UUID, role user.Role) error
+
 	// Bootstrap
 	BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error)
 }
@@ -113,6 +116,10 @@ func (m *authManager) RevokePAT(ctx context.Context, id uuid.UUID) error {
 
 func (m *authManager) ListPATs(ctx context.Context) ([]*pat.PAT, error) {
 	return m.user.ListPATs(ctx)
+}
+
+func (m *authManager) UpdateUserRole(ctx context.Context, userID uuid.UUID, role user.Role) error {
+	return m.user.UpdateUserRole(ctx, userID, role)
 }
 
 func (m *authManager) BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error) {

--- a/internal/application/auth/mocks_test.go
+++ b/internal/application/auth/mocks_test.go
@@ -37,6 +37,10 @@ func (m *mockUserRepository) Upsert(ctx context.Context, u *user.User) (*user.Us
 	return args.Get(0).(*user.User), args.Error(1)
 }
 
+func (m *mockUserRepository) UpdateRole(ctx context.Context, id uuid.UUID, role user.Role) error {
+	return m.Called(ctx, id, role).Error(0)
+}
+
 // mockPATRepository is a testify mock for pat.PATRepository.
 type mockPATRepository struct{ mock.Mock }
 

--- a/internal/application/auth/user_manager.go
+++ b/internal/application/auth/user_manager.go
@@ -22,6 +22,7 @@ type UserManager interface {
 	RevokePAT(ctx context.Context, id uuid.UUID) error
 	ListPATs(ctx context.Context) ([]*pat.PAT, error)
 	BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error)
+	UpdateUserRole(ctx context.Context, userID uuid.UUID, role user.Role) error
 }
 
 type userManager struct {
@@ -124,6 +125,13 @@ func (m *userManager) ListPATs(ctx context.Context) ([]*pat.PAT, error) {
 		return nil, fmt.Errorf("user manager: ListPATs: %w", err)
 	}
 	return pats, nil
+}
+
+func (m *userManager) UpdateUserRole(ctx context.Context, userID uuid.UUID, role user.Role) error {
+	if err := m.users.UpdateRole(ctx, userID, role); err != nil {
+		return fmt.Errorf("user manager: UpdateUserRole: %w", err)
+	}
+	return nil
 }
 
 func (m *userManager) BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error) {

--- a/internal/domain/user/repository.go
+++ b/internal/domain/user/repository.go
@@ -21,4 +21,8 @@ type UserRepository interface {
 	// or updates name, email, and updated_at if it does.
 	// Returns the persisted User (with ID and timestamps populated).
 	Upsert(ctx context.Context, u *User) (*User, error)
+
+	// UpdateRole sets the role for the user with the given ID.
+	// Returns ckerrors.ErrUserNotFound if no user exists with that ID.
+	UpdateRole(ctx context.Context, id uuid.UUID, role Role) error
 }

--- a/internal/infrastructure/postgres/user_repository.go
+++ b/internal/infrastructure/postgres/user_repository.go
@@ -83,6 +83,20 @@ func (r *UserRepository) Upsert(ctx context.Context, u *user.User) (*user.User, 
 	return result, nil
 }
 
+// UpdateRole implements user.UserRepository.
+func (r *UserRepository) UpdateRole(ctx context.Context, id uuid.UUID, role user.Role) error {
+	const q = `UPDATE users SET role = $1, updated_at = NOW() WHERE id = $2`
+
+	tag, err := r.db.Exec(ctx, q, role, id)
+	if err != nil {
+		return fmt.Errorf("postgres: UpdateRole: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("postgres: UpdateRole: %w", ckerrors.ErrUserNotFound)
+	}
+	return nil
+}
+
 // scanUser reads a user row from a pgx.Row.
 func scanUser(row pgx.Row) (*user.User, error) {
 	var u user.User


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/users/me` — returns the authenticated user's profile (id, email, role) from the JWT context; returns `200`
- Adds `PUT /api/v1/users/:id/role` — admin-only, updates a user's role; returns `200`
- Extends `UserRepository` with `UpdateRole`, cascaded through `UserManager` and `AuthManager`
- Role validation rejects values outside `admin` / `user`

## Test plan

- [x] `TestMe_Returns200WithUserProfile`
- [x] `TestUpdateRole_AsAdmin_Returns200`
- [x] `TestUpdateRole_AsNonAdmin_Returns403`
- [x] `TestUpdateRole_InvalidID_Returns400`
- [x] `TestUpdateRole_InvalidRole_Returns400`
- [x] `TestUpdateRole_ManagerError_Returns500`
- [x] Full regression suite passes (`make test`)

Closes #19
Spec: docs/specs/FEATURE_authentication/03_tasks.md (T-13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)