### PR TITLE
[CK-3] scaffold infra/cicd/ workspace and root Makefile dispatcher (TASK-001)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 .PHONY: build run test test-int test-all lint fmt clean \
         db-migrate db-rollback db-status \
-        web-install web-start web-build web-test
+        web-install web-start web-build web-test \
+        cicd-spec-ref cicd-backend-cov cicd-frontend-cov cicd-adr
 
 ## api targets
 build:
@@ -38,6 +39,19 @@ db-rollback:
 
 db-status:
 	$(MAKE) -C db status
+
+## cicd targets
+cicd-spec-ref:
+	$(MAKE) -C infra/cicd check-spec-ref
+
+cicd-backend-cov:
+	$(MAKE) -C infra/cicd check-backend-cov
+
+cicd-frontend-cov:
+	$(MAKE) -C infra/cicd check-frontend-cov
+
+cicd-adr:
+	$(MAKE) -C infra/cicd check-adr
 
 ## web targets
 web-install:

--- a/infra/cicd/Makefile
+++ b/infra/cicd/Makefile
@@ -1,0 +1,18 @@
+# infra/cicd/Makefile — CI check targets
+#
+# Each target is a standalone check runnable locally by setting the required
+# environment variables. See README.md for the full list per target.
+
+.PHONY: check-spec-ref check-backend-cov check-frontend-cov check-adr
+
+check-spec-ref:
+	@echo "not implemented" && exit 0
+
+check-backend-cov:
+	@echo "not implemented" && exit 0
+
+check-frontend-cov:
+	@echo "not implemented" && exit 0
+
+check-adr:
+	@echo "not implemented" && exit 0

--- a/infra/cicd/README.md
+++ b/infra/cicd/README.md
@@ -1,0 +1,71 @@
+# infra/cicd
+
+CI check scripts for the CourtKnights repository.
+
+Each check is a standalone script invoked by its Makefile target. All checks
+are runnable locally without triggering GitHub Actions by setting the required
+environment variables and calling `make -C infra/cicd <target>` from the
+repository root, or `make cicd-<target>` from the root dispatcher.
+
+---
+
+## Targets and required environment variables
+
+### `check-spec-ref`
+
+Verifies that a PR body contains a `Spec: docs/specs/` reference and that the
+referenced spec has an approved `05_acceptance.md`.
+
+| Variable | Description |
+|----------|-------------|
+| `PR_BODY` | Full text of the PR description |
+| `PR_LABELS` | Comma-separated list of PR labels |
+
+```bash
+PR_BODY="..." PR_LABELS="" make cicd-spec-ref
+```
+
+---
+
+### `check-backend-cov`
+
+Runs unit and integration tests and checks per-layer coverage thresholds.
+
+No additional environment variables required beyond a working Go environment
+and Docker (for Testcontainers).
+
+```bash
+make cicd-backend-cov
+```
+
+---
+
+### `check-frontend-cov`
+
+Runs the Angular test suite with coverage and checks global and per-service
+thresholds.
+
+No additional environment variables required beyond Node.js and installed
+`web/` dependencies.
+
+```bash
+make cicd-frontend-cov
+```
+
+---
+
+### `check-adr`
+
+Calls the Claude API to check whether the PR diff contradicts any active ADR.
+Posts a GitHub comment and applies labels as needed.
+
+| Variable | Description |
+|----------|-------------|
+| `PR_NUMBER` | GitHub PR number |
+| `GITHUB_TOKEN` | GitHub token with `pull-requests: write` |
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+| `GITHUB_REPOSITORY` | Repository in `owner/repo` format |
+
+```bash
+PR_NUMBER=42 GITHUB_TOKEN=... ANTHROPIC_API_KEY=... GITHUB_REPOSITORY=courtknights/courtknights make cicd-adr
+```


### PR DESCRIPTION
## Summary

- Creates `infra/cicd/Makefile` with four stub targets: `check-spec-ref`, `check-backend-cov`, `check-frontend-cov`, `check-adr`
- Creates `infra/cicd/README.md` with workspace purpose and local execution model per target
- Adds `cicd-*` dispatcher section to the root `Makefile`

## Test plan

- [x] `make cicd-spec-ref` exits 0 from repository root
- [x] `make cicd-backend-cov` exits 0 from repository root
- [x] `make cicd-frontend-cov` exits 0 from repository root
- [x] `make cicd-adr` exits 0 from repository root

Spec: docs/specs/FEATURE_ci_checks/02_architecture.md
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)