### PR TITLE
[CK-3] implement spec reference check (TASK-002)

### DIFF
--- a/docs/testing/regression_map.md
+++ b/docs/testing/regression_map.md
@@ -3,7 +3,7 @@
 Tracks dependencies between features. Update this file every time a feature is merged.
 When a feature is modified, all dependent features in this map must have their tests re-run.
 
-- **Last updated:** 2026-03-23
+- **Last updated:** 2026-03-26
 
 ---
 
@@ -29,3 +29,5 @@ When a feature is modified, all dependent features in this map must have their t
 | FEATURE_authentication / api/users | User management handlers (`/api/v1/users`) | application/auth, api/internal/api/common | — |
 | FEATURE_authentication / cmd/server | Server entrypoint, wiring, bootstrap hook | All of the above | — |
 | FEATURE_repo_workspaces | Repository layout (api/, db/, web/, infra/, e2e/) + workspace Makefiles + go.work | — | All features (path changes affect every workspace) |
+| FEATURE_ci_checks / TASK-001 | `infra/cicd/` workspace scaffold + stub Makefile targets + root Makefile dispatcher | FEATURE_repo_workspaces | FEATURE_ci_checks / TASK-002..006 |
+| FEATURE_ci_checks / TASK-002 | `check_spec_ref.sh` — spec reference check (no-spec label, Spec: line, 05_acceptance.md, Status: approved) | FEATURE_ci_checks / TASK-001 | FEATURE_ci_checks / TASK-006 |

--- a/infra/cicd/Makefile
+++ b/infra/cicd/Makefile
@@ -6,7 +6,7 @@
 .PHONY: check-spec-ref check-backend-cov check-frontend-cov check-adr
 
 check-spec-ref:
-	@echo "not implemented" && exit 0
+	@bash "$(CURDIR)/check_spec_ref.sh"
 
 check-backend-cov:
 	@echo "not implemented" && exit 0

--- a/infra/cicd/check_spec_ref.sh
+++ b/infra/cicd/check_spec_ref.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check_spec_ref.sh — Spec reference check
+#
+# Verifies that a PR body contains a valid spec reference pointing to an approved
+# acceptance document in docs/specs/.
+#
+# Required environment variables:
+#   PR_BODY   — full text of the PR description
+#   PR_LABELS — comma-separated list of labels on the PR (may be empty)
+#
+# Exits 0 if the check passes or the PR is exempt via the 'no-spec' label.
+# Exits 1 if the check fails.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# 1. Check for no-spec exemption
+if echo "${PR_LABELS:-}" | grep -qF "no-spec"; then
+    echo "Exempt: PR has 'no-spec' label — skipping spec reference check."
+    exit 0
+fi
+
+# 2. Check for spec reference line.
+# printf '%b' expands literal \n sequences that may appear when PR_BODY is passed
+# via shell assignment (e.g. PR_BODY="line1\nSpec: docs/specs/...").
+SPEC_LINE=$(printf '%b' "${PR_BODY:-}" | grep -F "Spec: docs/specs/" | head -n1 || true)
+
+if [ -z "$SPEC_LINE" ]; then
+    echo "ERROR: PR body does not contain a 'Spec: docs/specs/' line."
+    echo "Add a line like: Spec: docs/specs/FEATURE_xxx/02_architecture.md"
+    exit 1
+fi
+
+# 3. Extract the spec path (everything after "Spec: ", whitespace trimmed)
+SPEC_PATH=$(echo "$SPEC_LINE" | sed 's/.*Spec: //' | tr -d '[:space:]')
+
+# 4. Validate it starts with docs/specs/ (rejects paths like "some/other/path")
+case "$SPEC_PATH" in
+    docs/specs/*)
+        ;;
+    *)
+        echo "ERROR: Spec path must start with 'docs/specs/'. Got: $SPEC_PATH"
+        exit 1
+        ;;
+esac
+
+# 5. Derive the spec directory from the file path
+SPEC_DIR=$(dirname "$SPEC_PATH")
+
+# 6. Check that 05_acceptance.md exists in the spec directory
+ACCEPTANCE_FILE="${REPO_ROOT}/${SPEC_DIR}/05_acceptance.md"
+if [ ! -f "$ACCEPTANCE_FILE" ]; then
+    echo "ERROR: Acceptance document not found: ${SPEC_DIR}/05_acceptance.md"
+    echo "The spec directory '${SPEC_DIR}' must contain a '05_acceptance.md' file."
+    exit 1
+fi
+
+# 7. Check that 05_acceptance.md contains Status: approved
+if ! grep -qF "Status: approved" "$ACCEPTANCE_FILE"; then
+    echo "ERROR: Acceptance criteria are not approved in: ${SPEC_DIR}/05_acceptance.md"
+    echo "The file must contain a line: Status: approved"
+    exit 1
+fi
+
+echo "OK: Spec reference check passed."
+exit 0


### PR DESCRIPTION
## Summary

- Implements `infra/cicd/check_spec_ref.sh` — validates that every PR body contains a `Spec: docs/specs/` line pointing to a spec directory with an approved `05_acceptance.md`
- Wires the script into the `check-spec-ref` target in `infra/cicd/Makefile`
- Updates `docs/testing/regression_map.md` with TASK-001 and TASK-002 entries

## Test plan

All functional test cases from `docs/specs/FEATURE_ci_checks/04_tests.md` run locally and pass:

- [x] TC-SPEC-001: valid spec reference + approved acceptance → exit 0
- [x] TC-SPEC-002: no spec line → exit 1
- [x] TC-SPEC-003: `no-spec` label → exit 0 (exempt)
- [x] TC-SPEC-004: missing `05_acceptance.md` → exit 1
- [x] TC-SPEC-005: acceptance `Status: draft` → exit 1
- [x] TC-SPEC-007: `Spec:` prefix with wrong path → exit 1
- [x] TC-SPEC-008: spec line among multiple body lines → exit 0

Spec: docs/specs/FEATURE_ci_checks/02_architecture.md

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)