### PR TITLE
[CK-64] TASK-003: Add design-branch content check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
 
+  design-content-check:
+    name: Design branch content check
+    runs-on: ubuntu-latest
+    if: endsWith(github.head_ref, '/000_design')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check only docs/specs/ is modified
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD \
+            | grep -vE '^docs/specs/' || true)
+          if [ -n "$CHANGED" ]; then
+            echo "ERROR: design branch may only modify files under docs/specs/"
+            echo "Offending files:"
+            echo "$CHANGED"
+            exit 1
+          fi
+          echo "OK: all changes are under docs/specs/"
+
   adr-consistency:
     name: ADR consistency check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #70
Spec: docs/specs/FEATURE_branching_workflow/

## Summary

- Adds `design-content-check` job to `ci.yml`.
- Triggers only when `head_ref` ends in `/000_design`.
- Checks out with `fetch-depth: 0` and diffs against the base branch.
- Fails with a list of offending files if any change falls outside `docs/specs/`.
- Passes silently if all changed files are under `docs/specs/`.

## Test plan

- [ ] PR from `feature/CK-XXX/000_design` modifying only `docs/specs/` → `design-content-check` passes.
- [ ] PR from `feature/CK-XXX/000_design` modifying a file outside `docs/specs/` → fails with offending file listed.
- [ ] PR from any other branch → `design-content-check` job is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)