### PR TITLE
fix: clarify Closes #N must be in PR body to auto-close GitHub issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ The rationale for framework and technology choices is captured in the ADRs. Alwa
 - Branch naming: `CK-{issue-number}_{short-description}` (e.g. `CK-1_sdd-scaffolding`)
 - Commit messages: `[CK-{issue-number}] {message}` — imperative mood, present tense (e.g. `[CK-1] add spec template for league creation`)
 - Every PR must:
-  - Reference the GitHub issue (`Closes #N`)
+  - Include `Closes #N` (exact syntax) in the PR **body** — this is what GitHub uses to auto-close the issue on merge. Do not use "References" or "See #N"; only `Closes`, `Fixes`, or `Resolves` trigger auto-close.
   - Reference the related spec (`Spec: docs/specs/...`)
   - Pass all CI checks before merge
 


### PR DESCRIPTION
## Summary

- Clarified that `Closes #N` must appear in the PR **body** for GitHub to auto-close the issue on merge
- Noted that `Fixes` and `Resolves` also work, but `References` or `See #N` do not trigger auto-close
- Previous wording was ambiguous and led to PRs being merged without closing their linked issues

## Test plan

- [ ] Verify next merged PR automatically closes its linked GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)