### PR TITLE
[CK-71] TASK-004: document task sub-issues convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,17 @@ A chore branch is for minor maintenance work that does not introduce new product
 - Task commit example: `[CK-68] add ADR-012 hierarchical branching strategy`
 - Chore commit example: `[CK-66] upgrade golangci-lint to v1.58`
 
+### GitHub Issues and sub-issues
+
+Each feature has a parent GitHub Issue (the feature issue). Every task issue created from `03_tasks.md` must be registered as a sub-issue of its feature issue using the GitHub sub-issues API:
+
+```bash
+gh api repos/{owner}/{repo}/issues/{feature-issue}/sub_issues \
+  --method POST --field sub_issue_id={task-issue-id}
+```
+
+This links task progress directly to the feature issue in the GitHub UI. Task issues close automatically when the feature branch merges to `main` (via `Closes #N` in the feature PR body). Do not close them manually before that point.
+
 ### PR requirements
 
 Every PR must:


### PR DESCRIPTION
Closes #71

Spec: docs/specs/FEATURE_branching_workflow/02_architecture.md

## Summary

- Documents that task issues must be registered as sub-issues of the feature issue via the GitHub sub-issues API
- Explains that task issues close automatically when the feature branch merges to `main` — not before
- Includes the `gh api` command to link a sub-issue

## Changes

- `CLAUDE.md`: new "GitHub Issues and sub-issues" section under Git Conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)