### PR TITLE
[CK-64] fix issue templates: use 'about' instead of 'description' in frontmatter

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_task.md
+++ b/.github/ISSUE_TEMPLATE/agent_task.md
@@ -1,6 +1,6 @@
 ---
 name: Agent Task
-description: A spec-driven task to be executed by the AI agent.
+about: A spec-driven task to be executed by the AI agent.
 labels: ["agent-task"]
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-description: Report a bug or unexpected behaviour.
+about: Report a bug or unexpected behaviour.
 labels: ["bug"]
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-description: Propose a new feature or improvement.
+about: Propose a new feature or improvement.
 labels: ["enhancement"]
 ---
 


### PR DESCRIPTION
## Summary

- Fixes the `about` field in all three issue templates — GitHub requires `about`, not `description`

## Type

- [x] Hotfix (`fix/CK-XXX_description` → `main`)

## References

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)