### PR TITLE
[CK-65] warn when Claude wraps response in code fences

### DIFF
--- a/docs/decisions/ADR-011_ai-adr-consistency-check.md
+++ b/docs/decisions/ADR-011_ai-adr-consistency-check.md
@@ -47,7 +47,9 @@ Claude is prompted to return a structured JSON object only:
 }
 ```
 
-Claude must not return free-form text — only this JSON object. The script validates the schema before acting on the response.
+Claude must not return free-form text — only this JSON object. The system prompt explicitly forbids wrapping the response in markdown code fences. The script validates the schema before acting on the response.
+
+As a defensive fallback against LLM non-determinism, the script strips any leading/trailing code fences before parsing. If stripping occurs, a `::warning::` annotation is emitted in CI so the non-compliance is visible to a human. This fallback is intentional and must be retained alongside the prompt instruction: the prompt reduces the frequency of non-compliance; the stripping prevents hard failures on the rare occasions it still occurs.
 
 ### Severity model
 

--- a/infra/cicd/check_adr_consistency.py
+++ b/infra/cicd/check_adr_consistency.py
@@ -123,11 +123,11 @@ def call_claude(adrs: dict[str, str], diff: str) -> dict:
     stripped = re.sub(r"\s*```$", "", stripped)
     if stripped != raw.strip():
         print(
-            "WARNING: Claude wrapped its response in markdown code fences. "
-            "This violates the response contract defined in ADR-011 "
+            "::warning::Claude wrapped its response in markdown code fences, "
+            "violating the response contract defined in ADR-011 "
             "(Claude must return only a JSON object, no free-form text). "
-            "Proceeding with parsing after stripping the fences.",
-            file=sys.stderr,
+            "If this happens consistently, update the prompt or revisit ADR-011. "
+            "Proceeding with parsing after stripping the fences."
         )
     try:
         return json.loads(stripped)

--- a/infra/cicd/check_adr_consistency.py
+++ b/infra/cicd/check_adr_consistency.py
@@ -121,6 +121,14 @@ def call_claude(adrs: dict[str, str], diff: str) -> dict:
     # Strip optional markdown code fences (```json ... ``` or ``` ... ```)
     stripped = re.sub(r"^```(?:json)?\s*", "", raw.strip(), flags=re.IGNORECASE)
     stripped = re.sub(r"\s*```$", "", stripped)
+    if stripped != raw.strip():
+        print(
+            "WARNING: Claude wrapped its response in markdown code fences. "
+            "This violates the response contract defined in ADR-011 "
+            "(Claude must return only a JSON object, no free-form text). "
+            "Proceeding with parsing after stripping the fences.",
+            file=sys.stderr,
+        )
     try:
         return json.loads(stripped)
     except json.JSONDecodeError as exc:

--- a/infra/cicd/check_adr_consistency.py
+++ b/infra/cicd/check_adr_consistency.py
@@ -57,7 +57,8 @@ Respond ONLY with a JSON object matching this schema:
 }
 
 If there are no violations, return { "violations": [], "adr_files_modified": [...] }.
-Do not include any text outside the JSON object."""
+Do not include any text outside the JSON object.
+Do not wrap the response in markdown code fences (no ``` or ```json)."""
 
 ADR_CHANGE_LABEL = "adr-change"
 


### PR DESCRIPTION
## Summary

- Adds a `WARNING` log to stderr when Claude's response contains markdown code fences, making the ADR-011 contract violation visible instead of silently normalising it
- The stripping behaviour is preserved for resilience — the warning provides observability without breaking the check

## Type

- [x] Hotfix (`fix/CK-XXX_description` → `main`)

## References

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)