### PR TITLE
[CK-93] Design spec: FEATURE_user_profile

### DIFF
--- a/docs/specs/FEATURE_user_profile/01_business.md
+++ b/docs/specs/FEATURE_user_profile/01_business.md
@@ -1,7 +1,7 @@
 # FEATURE_user_profile — Business Context
 
 - **Last updated:** 2026-04-02
-- **Status:** draft
+- **Status:** approved
 - **Issue:** [#93](https://github.com/courtknights/courtknights/issues/93)
 
 ---

--- a/docs/specs/FEATURE_user_profile/01_business.md
+++ b/docs/specs/FEATURE_user_profile/01_business.md
@@ -36,6 +36,14 @@ Add a **user profile** system that allows each user to maintain a richer public 
 
 Country and region are validated using an embedded dataset (no external API). City is free text to accommodate the wide variety of naming conventions across locales. If `region` is provided, `country` must also be provided.
 
+### Sport identity
+
+| Field | Type | Values | Notes |
+|-------|------|--------|-------|
+| `gender` | enum | `male`, `female` | Required for tournament category assignment. |
+| `date_of_birth` | date | ISO 8601 (`YYYY-MM-DD`) | Used for age-group tournament eligibility. |
+| `category` | enum | `first`, `second`, `third`, `fourth`, `fifth` | Federative category, self-declared. |
+
 ### Preferences
 
 Stored as a **JSONB column** in PostgreSQL. This allows new preference fields to be added in the future without a schema migration.

--- a/docs/specs/FEATURE_user_profile/01_business.md
+++ b/docs/specs/FEATURE_user_profile/01_business.md
@@ -30,9 +30,11 @@ Add a **user profile** system that allows each user to maintain a richer public 
 
 | Field | Type | Notes |
 |-------|------|-------|
-| `city` | string | Optional. |
-| `region` | string | Optional. |
-| `country` | string | Optional. |
+| `city` | string | Optional. Free text — no validation applied. |
+| `region` | string | Optional. ISO 3166-2 subdivision code (e.g. `ES-MD` for Community of Madrid). Validated against the country. |
+| `country` | string | Optional. ISO 3166-1 alpha-2 code (e.g. `ES`, `US`). Validated on write. |
+
+Country and region are validated using an embedded dataset (no external API). City is free text to accommodate the wide variety of naming conventions across locales. If `region` is provided, `country` must also be provided.
 
 ### Preferences
 

--- a/docs/specs/FEATURE_user_profile/01_business.md
+++ b/docs/specs/FEATURE_user_profile/01_business.md
@@ -1,0 +1,127 @@
+# FEATURE_user_profile — Business Context
+
+- **Last updated:** 2026-04-02
+- **Status:** draft
+- **Issue:** [#93](https://github.com/courtknights/courtknights/issues/93)
+
+---
+
+## Problem
+
+Once a user is created via authentication, there is no way to enrich their identity with personal or sport-specific information. The platform only stores the minimal identity record required for authentication (email, display name from OAuth provider, role). This blocks features that depend on knowing who a player is, how they play, or how to find them within the community.
+
+---
+
+## Goal
+
+Add a **user profile** system that allows each user to maintain a richer public identity beyond the authentication record. The profile is created automatically at registration (pre-filled from the OAuth provider) and can be updated at any time by the owner.
+
+---
+
+## Profile fields
+
+### Identity
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `display_name` | string | Public name, changeable by the user. Pre-filled from the OAuth provider `name` at registration. |
+
+### Location
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `city` | string | Optional. |
+| `region` | string | Optional. |
+| `country` | string | Optional. |
+
+### Preferences
+
+Stored as a **JSONB column** in PostgreSQL. This allows new preference fields to be added in the future without a schema migration.
+
+| Preference | Type | Values |
+|------------|------|--------|
+| `court_side` | enum | `drive`, `backhand`, `both` |
+| `handedness` | enum | `right`, `left` |
+
+The preferences schema is open: additional fields can be introduced in future features by convention, without altering the database schema.
+
+---
+
+## User stories
+
+### US-01 — View my own profile
+
+> As a signed-in user, I want to see my profile so that I can review what information is visible to others.
+
+**Acceptance criteria:**
+- `GET /api/v1/users/me/profile` returns the authenticated user's full profile.
+- The response includes display name, location fields, and preferences.
+
+---
+
+### US-02 — Update my profile
+
+> As a signed-in user, I want to update my profile so that my display name, location, and sport preferences reflect my current situation.
+
+**Acceptance criteria:**
+- `PUT /api/v1/users/me/profile` updates the authenticated user's profile.
+- Partial updates are supported — only the fields included in the request body are changed.
+- The updated profile is returned in the response.
+
+---
+
+### US-03 — View another user's profile
+
+> As a signed-in user, I want to view another user's profile by their ID so that I can learn about other players in the community.
+
+**Acceptance criteria:**
+- `GET /api/v1/users/:id/profile` returns the profile for any user by their UUID.
+- Any authenticated user can view any other user's profile.
+- Returns `404` if the user does not exist.
+
+---
+
+### US-04 — List users
+
+> As a signed-in user, I want to browse the list of users on the platform so that I can discover other players.
+
+**Acceptance criteria:**
+- `GET /api/v1/users` returns a paginated list of users.
+- The caller can select which fields to include via a `fields` query parameter (e.g. `?fields=id,display_name,country`).
+- Pagination is cursor-based or page-based (decided in architecture phase).
+- Any authenticated user can call this endpoint.
+
+---
+
+## Pre-fill at registration
+
+When a new user is created via OAuth (Google or GitHub), their profile is initialised automatically:
+
+- `display_name` ← set from the OAuth provider `name`.
+- All other fields are left empty.
+
+The user can update all fields at any time after registration.
+
+---
+
+## Visibility
+
+All profile fields are public to any authenticated user. There are no per-field privacy settings in this iteration.
+
+---
+
+## Out of scope
+
+- Avatar / photo upload
+- Additional fields pre-filled from OAuth provider (e.g. avatar URL, locale)
+- Per-field privacy settings
+- Profile search or filtering beyond field selection on the list endpoint
+- Profile deletion (covered by account deletion, out of scope in FEATURE_authentication)
+
+---
+
+## Dependencies
+
+- **FEATURE_authentication** — the User entity and JWT middleware are prerequisites
+- **ADR-003** (PostgreSQL) — profile data is persisted in PostgreSQL; preferences use JSONB
+- **ADR-001** (Echo) — profile endpoints are implemented as Echo handlers

--- a/docs/specs/FEATURE_user_profile/02_architecture.md
+++ b/docs/specs/FEATURE_user_profile/02_architecture.md
@@ -1,0 +1,407 @@
+# FEATURE_user_profile — Architecture
+
+- **Last updated:** 2026-04-02
+- **Status:** draft
+- **Issue:** [#93](https://github.com/courtknights/courtknights/issues/93)
+
+---
+
+## Component overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Backend (Echo)                    │
+│                                                     │
+│  /api/v1/users      ──►  api/users/handler          │
+│  /api/v1/users/me/profile                           │
+│  /api/v1/users/:id/profile                          │
+│                          │                          │
+│                          ▼                          │
+│               application/profile                   │
+│               (ProfileManager)                      │
+│                          │                          │
+│               domain/profile/                       │
+│               (Profile entity + repository iface)   │
+│                          │                          │
+│               infrastructure/postgres               │
+│               (ProfileRepository impl)              │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## Internal package structure
+
+```
+api/internal/
+  domain/
+    profile/
+      profile.go          # Profile entity, enums (Gender, Category, CourtSide, Handedness)
+      preferences.go      # Preferences value object (JSONB-mapped struct)
+      repository.go       # ProfileRepository interface
+      validate.go         # Location validation (ISO 3166-1 / ISO 3166-2)
+  application/
+    profile/
+      manager.go          # ProfileManager — business logic
+  infrastructure/
+    postgres/
+      profile_repository.go  # ProfileRepository implementation
+  api/
+    users/
+      handler.go          # Extended with profile endpoints (existing file)
+      routes.go           # Extended with new routes (existing file)
+```
+
+The existing `api/users/` module is extended rather than replaced. `AuthManager` is also extended to call `ProfileRepository.EnsureExists` on every login (idempotent profile initialisation).
+
+---
+
+## Domain layer
+
+### Profile entity
+
+```go
+// domain/profile/profile.go
+
+type Gender   string
+type Category string
+type CourtSide  string
+type Handedness string
+
+const (
+    GenderMale   Gender = "male"
+    GenderFemale Gender = "female"
+
+    CategoryFirst  Category = "first"
+    CategorySecond Category = "second"
+    CategoryThird  Category = "third"
+    CategoryFourth Category = "fourth"
+    CategoryFifth  Category = "fifth"
+
+    CourtSideDrive    CourtSide = "drive"
+    CourtSideBackhand CourtSide = "backhand"
+    CourtSideBoth     CourtSide = "both"
+
+    HandednessRight Handedness = "right"
+    HandednessLeft  Handedness = "left"
+)
+
+type Profile struct {
+    UserID      uuid.UUID
+    DisplayName string
+    City        *string
+    Region      *string   // ISO 3166-2 code, e.g. "ES-MD"
+    Country     *string   // ISO 3166-1 alpha-2 code, e.g. "ES"
+    Gender      *Gender
+    DateOfBirth *time.Time
+    Category    *Category
+    Preferences Preferences
+    CreatedAt   time.Time
+    UpdatedAt   time.Time
+}
+```
+
+### Preferences value object
+
+```go
+// domain/profile/preferences.go
+
+// Preferences holds sport-specific settings stored as JSONB.
+// All fields are optional. New fields can be added here without a schema migration.
+type Preferences struct {
+    CourtSide  *CourtSide  `json:"court_side,omitempty"`
+    Handedness *Handedness `json:"handedness,omitempty"`
+}
+```
+
+### Location validation
+
+```go
+// domain/profile/validate.go
+
+// ValidateLocation returns an error if country or region are not valid ISO codes,
+// or if region is provided without country.
+// Uses an embedded dataset — no external API call.
+func ValidateLocation(country, region *string) error
+```
+
+Implemented using `github.com/biter777/countries` (see New dependencies).
+
+Rules:
+- `country` must be a valid ISO 3166-1 alpha-2 code if provided.
+- `region` must be a valid ISO 3166-2 code for the given `country` if provided.
+- If `region` is provided, `country` must also be provided.
+
+### ProfileRepository interface
+
+```go
+// domain/profile/repository.go
+
+type ProfileRepository interface {
+    // EnsureExists creates the profile with the given display name if it does not exist.
+    // No-op if a profile already exists for the user. Safe to call on every login.
+    EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error
+
+    // FindByUserID returns the profile for the given user.
+    // Returns ckerrors.ErrProfileNotFound if no profile exists.
+    FindByUserID(ctx context.Context, userID uuid.UUID) (*Profile, error)
+
+    // Update applies a partial update to the profile.
+    // Only non-nil fields in the patch are written.
+    Update(ctx context.Context, userID uuid.UUID, patch ProfilePatch) (*Profile, error)
+
+    // List returns a paginated list of profiles joined with basic user data.
+    List(ctx context.Context, params ListParams) ([]*ProfileListItem, int64, error)
+}
+
+// ProfilePatch carries the fields to update. Nil means "leave unchanged".
+type ProfilePatch struct {
+    DisplayName *string
+    City        *string
+    Region      *string
+    Country     *string
+    Gender      *Gender
+    DateOfBirth *time.Time
+    Category    *Category
+    Preferences *Preferences
+}
+
+// ListParams controls pagination and field selection for the list endpoint.
+type ListParams struct {
+    Page     int
+    PageSize int
+    Fields   []string // subset of allowed fields; empty = all fields
+}
+
+// ProfileListItem is a projection used by the list endpoint.
+// All fields are pointers so that omitted fields serialise as null / absent.
+type ProfileListItem struct {
+    ID          *uuid.UUID
+    DisplayName *string
+    City        *string
+    Region      *string
+    Country     *string
+    Gender      *Gender
+    Category    *Category
+}
+```
+
+---
+
+## Application layer
+
+### ProfileManager
+
+```go
+// application/profile/manager.go
+
+type ProfileManager struct {
+    profiles profile.ProfileRepository
+}
+
+func NewProfileManager(profiles profile.ProfileRepository) *ProfileManager
+
+// EnsureExists delegates to the repository (called by AuthManager on login).
+func (m *ProfileManager) EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error
+
+// GetByUserID returns a profile, returning ErrProfileNotFound if absent.
+func (m *ProfileManager) GetByUserID(ctx context.Context, userID uuid.UUID) (*profile.Profile, error)
+
+// Update validates the patch (location codes, enum values) and persists it.
+func (m *ProfileManager) Update(ctx context.Context, userID uuid.UUID, patch profile.ProfilePatch) (*profile.Profile, error)
+
+// List returns a paginated list with the requested fields.
+func (m *ProfileManager) List(ctx context.Context, params profile.ListParams) ([]*profile.ProfileListItem, int64, error)
+```
+
+Validation in `Update`:
+1. If `Country` or `Region` are set, call `profile.ValidateLocation`.
+2. Enum values (`Gender`, `Category`, `CourtSide`, `Handedness`) are typed — invalid values are rejected at deserialisation.
+
+### AuthManager change
+
+`AuthManager.ResolveByOAuth` and `AuthManager.BootstrapAdmin` are extended to call `ProfileManager.EnsureExists` after upserting the user. The call is idempotent (no-op on subsequent logins). `ProfileManager` is injected into `AuthManager` at wiring time.
+
+---
+
+## Infrastructure layer
+
+### Database schema
+
+```sql
+-- db/schema/user_profiles.sql
+CREATE TABLE user_profiles (
+    user_id       UUID         PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    display_name  VARCHAR(255) NOT NULL,
+    city          VARCHAR(255),
+    region        VARCHAR(10),
+    country       VARCHAR(2),
+    gender        VARCHAR(10)  CHECK (gender IN ('male', 'female')),
+    date_of_birth DATE,
+    category      VARCHAR(10)  CHECK (category IN ('first','second','third','fourth','fifth')),
+    preferences   JSONB        NOT NULL DEFAULT '{}',
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+```
+
+A migration adds this table. No changes to `users` table.
+
+### ProfileRepository (postgres)
+
+- `EnsureExists`: `INSERT INTO user_profiles ... ON CONFLICT (user_id) DO NOTHING`
+- `FindByUserID`: simple SELECT by `user_id`
+- `Update`: dynamic UPDATE building only the non-nil patch fields; returns the updated row
+- `List`: `SELECT u.id, p.display_name, p.city, ... FROM users u JOIN user_profiles p ON p.user_id = u.id ORDER BY p.display_name LIMIT $1 OFFSET $2`
+
+---
+
+## HTTP API contract
+
+All endpoints are protected (JWT required). Registered under `/api/v1`.
+
+### Get own profile
+
+```
+GET /api/v1/users/me/profile
+Authorization: Bearer <jwt>
+```
+
+**Response 200:**
+```json
+{
+  "user_id": "<uuid>",
+  "display_name": "Álvaro Agea",
+  "city": "Madrid",
+  "region": "ES-MD",
+  "country": "ES",
+  "gender": "male",
+  "date_of_birth": "1990-05-14",
+  "category": "third",
+  "preferences": {
+    "court_side": "drive",
+    "handedness": "right"
+  },
+  "updated_at": "2026-04-02T12:00:00Z"
+}
+```
+
+### Update own profile
+
+```
+PUT /api/v1/users/me/profile
+Authorization: Bearer <jwt>
+Content-Type: application/json
+```
+
+**Request** (all fields optional — partial update):
+```json
+{
+  "display_name": "Álvaro",
+  "city": "Madrid",
+  "region": "ES-MD",
+  "country": "ES",
+  "gender": "male",
+  "date_of_birth": "1990-05-14",
+  "category": "third",
+  "preferences": {
+    "court_side": "drive"
+  }
+}
+```
+
+**Response 200:** updated profile (same shape as GET).
+
+**Errors:**
+- `400` — invalid ISO code, unknown enum value, or region without country.
+
+### Get profile by ID
+
+```
+GET /api/v1/users/:id/profile
+Authorization: Bearer <jwt>
+```
+
+**Response 200:** same shape as GET own profile.
+**Response 404:** user or profile not found.
+
+### List users
+
+```
+GET /api/v1/users?page=1&page_size=20&fields=id,display_name,country,category
+Authorization: Bearer <jwt>
+```
+
+**Query params:**
+
+| Param | Default | Notes |
+|-------|---------|-------|
+| `page` | `1` | 1-based page number |
+| `page_size` | `20` | Max `100` |
+| `fields` | all | Comma-separated subset of: `id`, `display_name`, `city`, `region`, `country`, `gender`, `category` |
+
+**Response 200:**
+```json
+{
+  "data": [
+    { "id": "<uuid>", "display_name": "Álvaro", "country": "ES", "category": "third" }
+  ],
+  "total": 42,
+  "page": 1,
+  "page_size": 20
+}
+```
+
+---
+
+## Routing changes
+
+`api/users/routes.go` adds:
+
+```
+GET  /api/v1/users                     → handler.ListUsers
+GET  /api/v1/users/me/profile          → handler.GetMyProfile
+PUT  /api/v1/users/me/profile          → handler.UpdateMyProfile
+GET  /api/v1/users/:id/profile         → handler.GetUserProfile
+```
+
+Existing routes (`GET /api/v1/users/me`, `PUT /api/v1/users/:id/role`) are unchanged.
+
+---
+
+## New dependencies required
+
+> All additions must be approved before implementation and registered in `Dependency.md`.
+
+| Package | Purpose | License |
+|---------|---------|---------|
+| `github.com/biter777/countries` | ISO 3166-1 alpha-2 country and ISO 3166-2 subdivision validation — embedded dataset, no external API | MIT |
+
+---
+
+## Migration
+
+A new migration file is added under `db/migrations/`:
+
+```
+db/migrations/
+  NNNN_create_user_profiles.up.sql
+  NNNN_create_user_profiles.down.sql
+```
+
+The `up` migration creates `user_profiles` and backfills existing users:
+
+```sql
+CREATE TABLE user_profiles (...);
+
+-- Backfill profiles for users created before this feature.
+INSERT INTO user_profiles (user_id, display_name)
+SELECT id, name FROM users
+ON CONFLICT (user_id) DO NOTHING;
+```
+
+---
+
+## Open questions
+
+None — all decisions are captured above or in the referenced ADRs.

--- a/docs/specs/FEATURE_user_profile/02_architecture.md
+++ b/docs/specs/FEATURE_user_profile/02_architecture.md
@@ -1,7 +1,7 @@
 # FEATURE_user_profile — Architecture
 
 - **Last updated:** 2026-04-02
-- **Status:** draft
+- **Status:** approved
 - **Issue:** [#93](https://github.com/courtknights/courtknights/issues/93)
 
 ---

--- a/docs/specs/FEATURE_user_profile/03_tasks.md
+++ b/docs/specs/FEATURE_user_profile/03_tasks.md
@@ -1,6 +1,6 @@
 # FEATURE_user_profile — Tasks
 
-- **Last updated:** 2026-04-02
+- **Last updated:** 2026-04-03
 - **Status:** approved
 - **Issue:** [#93](https://github.com/courtknights/courtknights/issues/93)
 - **Spec:** [01_business.md](01_business.md) · [02_architecture.md](02_architecture.md)
@@ -28,7 +28,7 @@ T-01 (domain)
 
 ---
 
-## T-01 — Domain layer: Profile entity, Preferences, repository interface, ckerrors
+## T-01 — Domain layer: Profile entity, Preferences, repository interface, ckerrors · [#96](https://github.com/courtknights/courtknights/issues/96)
 
 **Files to create:**
 
@@ -53,7 +53,7 @@ Rules for `ValidateLocation`:
 
 ---
 
-## T-02 — Database schema: user_profiles
+## T-02 — Database schema: user_profiles · [#97](https://github.com/courtknights/courtknights/issues/97)
 
 > No code dependencies. Can be worked on in parallel with T-01.
 
@@ -71,7 +71,7 @@ Schema and migration contents are specified in `02_architecture.md` (Database sc
 
 ---
 
-## T-03 — Infrastructure: PostgreSQL ProfileRepository
+## T-03 — Infrastructure: PostgreSQL ProfileRepository · [#98](https://github.com/courtknights/courtknights/issues/98)
 
 > Depends on T-01 + T-02.
 
@@ -93,7 +93,7 @@ Implementation notes (from `02_architecture.md`):
 
 ---
 
-## T-04 — Application: ProfileManager
+## T-04 — Application: ProfileManager · [#99](https://github.com/courtknights/courtknights/issues/99)
 
 > Depends on T-01.
 
@@ -113,7 +113,7 @@ Validation in `Update`:
 
 ---
 
-## T-05 — Auth integration: profile initialisation on login
+## T-05 — Auth integration: profile initialisation on login · [#100](https://github.com/courtknights/courtknights/issues/100)
 
 > Depends on T-03 + T-04.
 
@@ -134,7 +134,7 @@ The `EnsureExists` call must happen after the user upsert but before signing the
 
 ---
 
-## T-06 — API: own-profile and get-by-ID endpoints
+## T-06 — API: own-profile and get-by-ID endpoints · [#101](https://github.com/courtknights/courtknights/issues/101)
 
 > Depends on T-04.
 
@@ -160,7 +160,7 @@ Error mapping:
 
 ---
 
-## T-07 — API: list users endpoint
+## T-07 — API: list users endpoint · [#102](https://github.com/courtknights/courtknights/issues/102)
 
 > Depends on T-04. `profileManager` is already injected from T-06.
 

--- a/docs/specs/FEATURE_user_profile/03_tasks.md
+++ b/docs/specs/FEATURE_user_profile/03_tasks.md
@@ -1,0 +1,185 @@
+# FEATURE_user_profile — Tasks
+
+- **Last updated:** 2026-04-02
+- **Status:** approved
+- **Issue:** [#93](https://github.com/courtknights/courtknights/issues/93)
+- **Spec:** [01_business.md](01_business.md) · [02_architecture.md](02_architecture.md)
+
+> Each task maps to one GitHub Issue (label: `agent-task`) and one PR.
+> Tasks must be implemented in the order listed — each depends on all prior tasks unless stated otherwise.
+
+---
+
+## Dependency graph
+
+```
+T-01 (domain)
+  │
+  ├── T-02 (schema)          ← no code deps, can start in parallel with T-01
+  │     │
+  │     └── T-03 (postgres repo) ── depends on T-01 + T-02
+  │
+  └── T-04 (manager) ──────────── depends on T-01
+        │
+        ├── T-05 (auth integration) ── depends on T-03 + T-04
+        ├── T-06 (api: profile endpoints) ── depends on T-04
+        └── T-07 (api: list users) ────────── depends on T-04
+```
+
+---
+
+## T-01 — Domain layer: Profile entity, Preferences, repository interface, ckerrors
+
+**Files to create:**
+
+| File                                         | Description                                                                                |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `api/internal/domain/profile/profile.go`     | `Profile` struct; enums `Gender`, `Category`, `CourtSide`, `Handedness` with all constants |
+| `api/internal/domain/profile/preferences.go` | `Preferences` value object (JSONB-mapped struct)                                           |
+| `api/internal/domain/profile/repository.go`  | `ProfileRepository` interface; `ProfilePatch`, `ListParams`, `ProfileListItem` types       |
+| `api/internal/domain/profile/validate.go`    | `ValidateLocation(country, region *string) error`                                          |
+| `api/internal/domain/ckerrors/profile.go`    | Sentinel error: `ErrProfileNotFound`                                                       |
+
+`ValidateLocation` uses `github.com/biter777/countries`. This dependency must be added to `go.mod` and `Dependency.md`.
+
+Rules for `ValidateLocation`:
+- Both `nil` → no error.
+- `country` non-nil → must be a valid ISO 3166-1 alpha-2 code; otherwise error.
+- `region` non-nil → `country` must also be non-nil; `region` must be a valid ISO 3166-2 code for that country; otherwise error.
+
+**Tests:** unit tests for `ValidateLocation`.
+
+**Acceptance:** `make test` passes; `domain/profile/` has no imports outside the Go standard library and `github.com/biter777/countries`.
+
+---
+
+## T-02 — Database schema: user_profiles
+
+> No code dependencies. Can be worked on in parallel with T-01.
+
+**Files to create:**
+
+| File                                              | Description                                                                |
+| ------------------------------------------------- | -------------------------------------------------------------------------- |
+| `db/schema/user_profiles.sql`                     | `user_profiles` table definition (reference only, not executed by migrate) |
+| `db/migrations/003_create_user_profiles.up.sql`   | Create `user_profiles` table; backfill existing users from `users`         |
+| `db/migrations/003_create_user_profiles.down.sql` | Drop `user_profiles`                                                       |
+
+Schema and migration contents are specified in `02_architecture.md` (Database schema and Migration sections).
+
+**Acceptance:** migrations run and reverse cleanly against a real PostgreSQL instance that already contains the `users` table.
+
+---
+
+## T-03 — Infrastructure: PostgreSQL ProfileRepository
+
+> Depends on T-01 + T-02.
+
+**Files to create:**
+
+| File                                                         | Description                                                                      |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `api/internal/infrastructure/postgres/profile_repository.go` | Implements `ProfileRepository`: `EnsureExists`, `FindByUserID`, `Update`, `List` |
+
+Implementation notes (from `02_architecture.md`):
+- `EnsureExists`: `INSERT INTO user_profiles ... ON CONFLICT (user_id) DO NOTHING`
+- `FindByUserID`: SELECT by `user_id`; return `ckerrors.ErrProfileNotFound` when no row
+- `Update`: build UPDATE dynamically from non-nil patch fields; return updated row
+- `List`: JOIN with `users` table; ORDER BY `display_name`; LIMIT/OFFSET from `ListParams`
+
+**Tests:** integration tests using Testcontainers (build tag `integration`). Add cases to the existing `TestMain` in `api/internal/infrastructure/postgres/integration_test.go`.
+
+**Acceptance:** `make test-int` passes.
+
+---
+
+## T-04 — Application: ProfileManager
+
+> Depends on T-01.
+
+**Files to create:**
+
+| File                                          | Description                                                                                 |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `api/internal/application/profile/manager.go` | `ProfileManager` interface + `profileManager` struct; all methods from `02_architecture.md` |
+
+Validation in `Update`:
+1. If `Country` or `Region` are non-nil, call `profile.ValidateLocation`.
+2. Return validation error before calling the repository if validation fails.
+
+**Tests:** unit tests with a mocked `ProfileRepository` (`testify/mock`).
+
+**Acceptance:** `make test` passes; no DB or network required.
+
+---
+
+## T-05 — Auth integration: profile initialisation on login
+
+> Depends on T-03 + T-04.
+
+**Files to modify:**
+
+| File                                       | Description                                                                                                                                                                  |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api/internal/application/auth/manager.go` | Add `profiles ProfileManager` field to `authManager`; call `profiles.EnsureExists` in `OAuthCallback`, `DevicePoll`, and `BootstrapAdmin` after the user is resolved/created |
+| `api/cmd/server/server.go`                 | Instantiate `profileManager`; inject into `NewAuthManager`                                                                                                                   |
+
+`NewAuthManager` gains a fourth parameter: `profiles appprofile.ProfileManager`.
+
+The `EnsureExists` call must happen after the user upsert but before signing the JWT. An error from `EnsureExists` must be propagated to the caller.
+
+**Tests:** unit tests extending `manager_test.go`. A mock `ProfileManager` must be added to `mocks_test.go`.
+
+**Acceptance:** `make test` passes; existing auth tests continue to pass.
+
+---
+
+## T-06 — API: own-profile and get-by-ID endpoints
+
+> Depends on T-04.
+
+**Files to modify:**
+
+| File                                | Description                                                                                        |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `api/internal/api/users/handler.go` | Add `profiles ProfileManager` field; implement `getMyProfile`, `updateMyProfile`, `getUserProfile` |
+| `api/internal/api/users/routes.go`  | Register `GET /users/me/profile`, `PUT /users/me/profile`, `GET /users/:id/profile`                |
+| `api/cmd/server/server.go`          | Pass `profileManager` to `users.NewHandler`                                                        |
+
+`users.NewHandler` gains a second parameter: `profiles appprofile.ProfileManager`.
+
+The authenticated user's ID is read from the JWT context via `common.ContextKeySub` (UUID string — must be parsed).
+
+Error mapping:
+- `ckerrors.ErrProfileNotFound` → `404`
+- validation errors from `ProfileManager.Update` → `400`
+
+**Tests:** unit tests in `api/internal/api/users/handler_profile_test.go` with a mocked `ProfileManager`.
+
+**Acceptance:** `make test` passes.
+
+---
+
+## T-07 — API: list users endpoint
+
+> Depends on T-04. `profileManager` is already injected from T-06.
+
+**Files to modify:**
+
+| File                                | Description           |
+| ----------------------------------- | --------------------- |
+| `api/internal/api/users/handler.go` | Implement `listUsers` |
+| `api/internal/api/users/routes.go`  | Register `GET /users` |
+
+Query parameter handling:
+- `page` (default `1`, minimum `1`)
+- `page_size` (default `20`, maximum `100`; return `400` if exceeded)
+- `fields` (comma-separated; empty = all allowed fields)
+
+Allowed field names: `id`, `display_name`, `city`, `region`, `country`, `gender`, `category`.
+
+Response shape: `{ "data": [...], "total": N, "page": N, "page_size": N }`.
+
+**Tests:** unit tests in `api/internal/api/users/handler_list_test.go` with a mocked `ProfileManager`.
+
+**Acceptance:** `make test` passes.

--- a/docs/specs/FEATURE_user_profile/04_tests.md
+++ b/docs/specs/FEATURE_user_profile/04_tests.md
@@ -1,0 +1,188 @@
+# FEATURE_user_profile — Test Cases
+
+- **Last updated:** 2026-04-02
+- **Status:** approved
+- **Issue:** [#93](https://github.com/courtknights/courtknights/issues/93)
+- **Spec:** [01_business.md](01_business.md) · [02_architecture.md](02_architecture.md) · [03_tasks.md](03_tasks.md)
+
+> Tests are grouped by task and level. All unit tests run with `make test`. All integration tests run with `make test-int`. Coverage minimums follow [docs/testing/strategy.md](../../testing/strategy.md).
+
+---
+
+## T-01 — Domain: ValidateLocation (unit)
+
+**File:** `api/internal/domain/profile/validate_test.go`
+**Build tag:** none (unit)
+**Minimum coverage:** ≥ 90%
+
+| ID | Description | Input | Expected outcome |
+|----|-------------|-------|-----------------|
+| VL-01 | Both nil — no validation | `country=nil`, `region=nil` | `nil` |
+| VL-02 | Valid country, no region | `country="ES"`, `region=nil` | `nil` |
+| VL-03 | Valid country + valid matching region | `country="ES"`, `region="ES-MD"` | `nil` |
+| VL-04 | Invalid country code | `country="XX"`, `region=nil` | error |
+| VL-05 | Valid country + region from a different country | `country="ES"`, `region="FR-75"` | error |
+| VL-06 | Valid country + invalid region format | `country="ES"`, `region="INVALID"` | error |
+| VL-07 | Region provided without country | `country=nil`, `region="ES-MD"` | error |
+| VL-08 | Empty string country (not nil) | `country=""`, `region=nil` | error |
+| VL-09 | Empty string region with valid country | `country="US"`, `region=""` | error |
+| VL-10 | Case-sensitive country code (lowercase) | `country="es"`, `region=nil` | error (codes must be uppercase) |
+
+---
+
+## T-03 — Infrastructure: ProfileRepository (integration)
+
+**File:** `api/internal/infrastructure/postgres/profile_repository_integration_test.go`
+**Build tag:** `//go:build integration`
+**Suite hook:** add cases to the existing `TestMain` in `integration_test.go`
+**Minimum coverage:** ≥ 70%
+
+### EnsureExists
+
+| ID | Description | Precondition | Expected outcome |
+|----|-------------|-------------|-----------------|
+| PR-01 | Creates a profile for a new user | User exists in `users`, no profile | Row inserted in `user_profiles`; `display_name` matches input |
+| PR-02 | No-op when profile already exists | Profile already exists for user | No error; existing row unchanged |
+| PR-03 | Non-existent user ID | User not in `users` table | FK violation error propagated |
+
+### FindByUserID
+
+| ID | Description | Precondition | Expected outcome |
+|----|-------------|-------------|-----------------|
+| PR-04 | Returns profile for existing user | Profile exists | `*Profile` with correct field values |
+| PR-05 | Returns ErrProfileNotFound when missing | No profile for the user | `ckerrors.ErrProfileNotFound` |
+| PR-06 | All nullable fields are null | Profile exists with only `display_name` set | `*Profile` with all pointers nil except `DisplayName` |
+
+### Update
+
+| ID | Description | Patch | Expected outcome |
+|----|-------------|-------|-----------------|
+| PR-07 | Partial update — only display_name | `{DisplayName: ptr("New")}` | Updated row returned; other fields unchanged |
+| PR-08 | Update all fields at once | All fields non-nil | Returned profile matches every patch field |
+| PR-09 | Update preferences | `{Preferences: &Preferences{CourtSide: ptr(CourtSideDrive)}}` | JSONB updated; other preference fields unchanged |
+| PR-10 | Update non-existent profile | No profile for user | Error or zero rows affected (implementation-defined) |
+
+### List
+
+| ID | Description | Params | Expected outcome |
+|----|-------------|--------|-----------------|
+| PR-11 | Returns all profiles ordered by display_name | Page=1, PageSize=100 | Slice ordered by `display_name` ASC; total count matches DB rows |
+| PR-12 | Pagination — first page | Page=1, PageSize=2, 5 profiles in DB | 2 items returned; total=5 |
+| PR-13 | Pagination — last page | Page=3, PageSize=2, 5 profiles in DB | 1 item returned; total=5 |
+| PR-14 | Page beyond total | Page=10, PageSize=2, 5 profiles in DB | Empty slice; total=5 |
+
+---
+
+## T-04 — Application: ProfileManager (unit)
+
+**File:** `api/internal/application/profile/manager_test.go`
+**Build tag:** none (unit)
+**Dependencies mocked:** `ProfileRepository` via `testify/mock`
+**Minimum coverage:** ≥ 80%
+
+### EnsureExists
+
+| ID | Description | Mock behaviour | Expected outcome |
+|----|-------------|---------------|-----------------|
+| PM-01 | Delegates to repository successfully | Repo returns nil | nil error |
+| PM-02 | Propagates repository error | Repo returns error | Same error returned |
+
+### GetByUserID
+
+| ID | Description | Mock behaviour | Expected outcome |
+|----|-------------|---------------|-----------------|
+| PM-03 | Returns profile from repository | Repo returns `*Profile` | Same `*Profile` returned |
+| PM-04 | Propagates ErrProfileNotFound | Repo returns `ErrProfileNotFound` | `ErrProfileNotFound` returned |
+
+### Update — validation
+
+| ID | Description | Patch | Expected outcome |
+|----|-------------|-------|-----------------|
+| PM-05 | No location fields — skips validation, calls repo | `{DisplayName: ptr("X")}` | Repo called; updated profile returned |
+| PM-06 | Valid country + valid region — calls repo | `{Country: ptr("ES"), Region: ptr("ES-MD")}` | Repo called; updated profile returned |
+| PM-07 | Invalid country — returns 400-style error before calling repo | `{Country: ptr("XX")}` | Error returned; repo **not** called |
+| PM-08 | Region without country — returns error before calling repo | `{Region: ptr("ES-MD")}` | Error returned; repo **not** called |
+| PM-09 | Valid country, mismatched region — returns error | `{Country: ptr("ES"), Region: ptr("FR-75")}` | Error returned; repo **not** called |
+
+### List
+
+| ID | Description | Mock behaviour | Expected outcome |
+|----|-------------|---------------|-----------------|
+| PM-10 | Delegates params to repository | Repo returns slice + count | Same slice and count returned |
+| PM-11 | Propagates repository error | Repo returns error | Same error returned |
+
+---
+
+## T-05 — Auth integration: profile init on login (unit)
+
+**File:** `api/internal/application/auth/manager_test.go` (extend existing)
+**Mocks file:** `api/internal/application/auth/mocks_test.go` (add `MockProfileManager`)
+**Build tag:** none (unit)
+
+| ID | Description | Scenario | Expected outcome |
+|----|-------------|----------|-----------------|
+| AI-01 | OAuthCallback calls EnsureExists after user upsert | OAuth flow completes; mock ProfileManager returns nil | JWT signed and returned; EnsureExists called once with correct userID and displayName |
+| AI-02 | OAuthCallback propagates EnsureExists error | Mock ProfileManager returns error | Error propagated; JWT not issued |
+| AI-03 | DevicePoll calls EnsureExists after user resolution | Device flow completes; mock returns nil | JWT signed; EnsureExists called once |
+| AI-04 | DevicePoll propagates EnsureExists error | Mock returns error | Error propagated |
+| AI-05 | BootstrapAdmin calls EnsureExists after admin user created | Bootstrap flow; mock returns nil | No error; EnsureExists called once |
+| AI-06 | BootstrapAdmin propagates EnsureExists error | Mock returns error | Error propagated |
+| AI-07 | Existing auth unit tests still pass | No behaviour change other than new EnsureExists call | All existing assertions pass with mock injected |
+
+---
+
+## T-06 — API: own-profile and get-by-ID handlers (unit)
+
+**File:** `api/internal/api/users/handler_profile_test.go`
+**Build tag:** none (unit)
+**Test infrastructure:** `net/http/httptest` + Echo test helpers
+**Dependencies mocked:** `ProfileManager` via `testify/mock`
+**Minimum coverage:** ≥ 80%
+
+### GET /users/me/profile
+
+| ID | Description | Mock behaviour | Expected HTTP |
+|----|-------------|---------------|--------------|
+| HP-01 | Returns own profile | Manager returns `*Profile` | 200 with full profile JSON |
+| HP-02 | Profile not found | Manager returns `ErrProfileNotFound` | 404 |
+| HP-03 | Missing JWT / invalid sub claim | JWT context absent | 401 (middleware) or 400 |
+
+### PUT /users/me/profile
+
+| ID | Description | Request body | Mock behaviour | Expected HTTP |
+|----|-------------|-------------|---------------|--------------|
+| HP-04 | Partial update — display_name only | `{"display_name":"X"}` | Manager returns updated `*Profile` | 200 with updated profile JSON |
+| HP-05 | Full update — all fields | All fields present | Manager returns `*Profile` | 200 |
+| HP-06 | Invalid country code | `{"country":"XX"}` | Manager returns validation error | 400 |
+| HP-07 | Region without country | `{"region":"ES-MD"}` | Manager returns validation error | 400 |
+| HP-08 | Unknown enum value for gender | `{"gender":"unknown"}` | Deserialisation or manager error | 400 |
+| HP-09 | Empty body (all fields omitted) | `{}` | Manager called with all-nil patch; returns existing profile | 200 |
+
+### GET /users/:id/profile
+
+| ID | Description | Mock behaviour | Expected HTTP |
+|----|-------------|---------------|--------------|
+| HP-10 | Returns profile for valid user ID | Manager returns `*Profile` | 200 with profile JSON |
+| HP-11 | Profile not found | Manager returns `ErrProfileNotFound` | 404 |
+| HP-12 | Malformed UUID in path | — | 400 |
+
+---
+
+## T-07 — API: list users handler (unit)
+
+**File:** `api/internal/api/users/handler_list_test.go`
+**Build tag:** none (unit)
+**Test infrastructure:** `net/http/httptest` + Echo test helpers
+**Dependencies mocked:** `ProfileManager` via `testify/mock`
+**Minimum coverage:** ≥ 80%
+
+| ID | Description | Query string | Mock behaviour | Expected HTTP / body |
+|----|-------------|-------------|---------------|---------------------|
+| LU-01 | Default params | (none) | Manager returns 2 items, total=2 | 200; `page=1`, `page_size=20`, `total=2` |
+| LU-02 | Explicit page and page_size | `?page=2&page_size=5` | Manager called with Page=2, PageSize=5 | 200; response reflects params |
+| LU-03 | Field selection | `?fields=id,display_name,country` | Manager called with Fields=["id","display_name","country"] | 200; items contain only requested fields |
+| LU-04 | page_size exceeds max (100) | `?page_size=101` | — | 400 |
+| LU-05 | page less than 1 | `?page=0` | — | 400 |
+| LU-06 | Unknown field name in fields | `?fields=id,unknown_field` | — | 400 |
+| LU-07 | Empty result set | (none) | Manager returns empty slice, total=0 | 200; `"data":[]`, `"total":0` |
+| LU-08 | Manager returns error | (none) | Manager returns error | 500 |

--- a/docs/specs/FEATURE_user_profile/05_acceptance.md
+++ b/docs/specs/FEATURE_user_profile/05_acceptance.md
@@ -1,0 +1,125 @@
+# FEATURE_user_profile — Acceptance Criteria
+
+- **Last updated:** 2026-04-03
+- **Status:** approved
+- **Issue:** [#93](https://github.com/courtknights/courtknights/issues/93)
+- **Author:** aagea
+
+
+> Acceptance criteria are verified manually by the human reviewer before closing the feature issue. They complement — not replace — the automated test suite defined in `04_tests.md`.
+
+---
+
+## AC-01 — Profile initialised on first login
+
+**Given** a user authenticates for the first time via OAuth (Google or GitHub)
+**When** the OAuth callback completes successfully
+**Then** a profile row exists in `user_profiles` for that user, with `display_name` set to the name provided by the OAuth provider and all other fields empty.
+
+**And** if the same user authenticates again, the existing profile is not overwritten.
+
+---
+
+## AC-02 — View own profile
+
+**Given** a signed-in user
+**When** they call `GET /api/v1/users/me/profile`
+**Then** the response is `200 OK` with a JSON body containing:
+- `user_id`, `display_name`, `updated_at` (always present)
+- `city`, `region`, `country`, `gender`, `date_of_birth`, `category`, `preferences` (present; may be `null` if not set)
+
+---
+
+## AC-03 — Update own profile (partial)
+
+**Given** a signed-in user with an existing profile
+**When** they call `PUT /api/v1/users/me/profile` with a subset of fields
+**Then** the response is `200 OK` with the updated profile; only the submitted fields have changed; all other fields retain their previous values.
+
+---
+
+## AC-04 — Update own profile (full)
+
+**Given** a signed-in user
+**When** they call `PUT /api/v1/users/me/profile` with all fields populated and valid
+**Then** the response is `200 OK` and every field in the response matches the submitted values.
+
+---
+
+## AC-05 — Location validation on update
+
+**Given** a signed-in user
+**When** they submit a `PUT /api/v1/users/me/profile` with an invalid ISO 3166-1 country code
+**Then** the response is `400 Bad Request`.
+
+**And** when they submit a valid country code with a region code that does not belong to that country
+**Then** the response is `400 Bad Request`.
+
+**And** when they submit a region code without a country code
+**Then** the response is `400 Bad Request`.
+
+---
+
+## AC-06 — View another user's profile
+
+**Given** a signed-in user and a second user with a profile
+**When** the first user calls `GET /api/v1/users/:id/profile` with the second user's UUID
+**Then** the response is `200 OK` with the second user's full profile.
+
+---
+
+## AC-07 — Profile not found
+
+**Given** a signed-in user
+**When** they call `GET /api/v1/users/:id/profile` with a UUID that does not correspond to any user
+**Then** the response is `404 Not Found`.
+
+---
+
+## AC-08 — List users (default pagination)
+
+**Given** at least one user with a profile exists
+**When** a signed-in user calls `GET /api/v1/users` with no query parameters
+**Then** the response is `200 OK` with:
+- `data`: array of user objects ordered by `display_name` ascending
+- `page`: `1`
+- `page_size`: `20`
+- `total`: total number of users in the platform
+
+---
+
+## AC-09 — List users (field selection)
+
+**Given** multiple users with profiles
+**When** a signed-in user calls `GET /api/v1/users?fields=id,display_name,country`
+**Then** each object in `data` contains only `id`, `display_name`, and `country`; no other fields are present.
+
+---
+
+## AC-10 — List users (pagination bounds)
+
+**Given** a signed-in user
+**When** they call `GET /api/v1/users?page_size=101`
+**Then** the response is `400 Bad Request`.
+
+**And** when they call `GET /api/v1/users?page=0`
+**Then** the response is `400 Bad Request`.
+
+---
+
+## AC-11 — Unauthenticated access is rejected
+
+**Given** an unauthenticated request (no JWT or expired JWT)
+**When** any profile endpoint is called (`GET /users/me/profile`, `PUT /users/me/profile`, `GET /users/:id/profile`, `GET /users`)
+**Then** the response is `401 Unauthorized`.
+
+---
+
+## AC-12 — Migration is reversible
+
+**Given** a PostgreSQL instance with the `users` table and existing user rows
+**When** migration `003_create_user_profiles.up.sql` is applied
+**Then** the `user_profiles` table exists and contains one row per pre-existing user.
+
+**And** when `003_create_user_profiles.down.sql` is applied
+**Then** the `user_profiles` table is dropped and the `users` table is unchanged.


### PR DESCRIPTION
## Summary

- Full spec for `FEATURE_user_profile`: business context, architecture, tasks, test cases, and acceptance criteria
- 7 task issues created (#96–#102) as sub-issues of #93, ready for agent execution
- Feature issue #93 reopened (was closed prematurely; it closes automatically on merge to `main`)

## Spec

Spec: docs/specs/FEATURE_user_profile/

## Documents included

| File | Status |
|------|--------|
| `01_business.md` | approved |
| `02_architecture.md` | approved |
| `03_tasks.md` | approved |
| `04_tests.md` | approved |
| `05_acceptance.md` | approved |

## Task issues

| Issue | Task |
|-------|------|
| #96 | T-01 — Domain layer |
| #97 | T-02 — Database schema |
| #98 | T-03 — PostgreSQL ProfileRepository |
| #99 | T-04 — ProfileManager |
| #100 | T-05 — Auth integration |
| #101 | T-06 — Own-profile endpoints |
| #102 | T-07 — List users endpoint |

🤖 Generated with [Claude Code](https://claude.com/claude-code)