### PR TITLE
[CK-93] sync feature/CK-93/branch with main

### DIFF
--- a/docs/decisions/ADR-012_branching-strategy.md
+++ b/docs/decisions/ADR-012_branching-strategy.md
@@ -74,6 +74,20 @@ Where `{issue}` is the GitHub Issue number associated with the feature branch, c
 
 For task PRs the title is the verbatim GitHub issue title, so the issue and PR are trivially linked without any formatting ceremony.
 
+### Branch protection and bypass policy
+
+GitHub rulesets are applied to `main` and `feature/**/branch` via `infra/rulesets/` and `make apply-rulesets`. Both rulesets include an `OrganizationAdmin` bypass actor with `bypass_mode: "pull_request"`.
+
+**Why `pull_request` and not `always`:** The bypass allows an org admin to merge a PR without satisfying the approval requirement, but it does not grant direct-push access. This means all changes — including those from org admins — must still go through a pull request and have CI checks pass. The bypass exists solely to unblock self-merge in a repository with very few contributors (currently a single-contributor project), where requiring a second reviewer would halt all progress.
+
+**Direct push is intentionally not allowed, even for org admins.** If a genuine emergency requires bypassing CI (e.g., a critical hotfix that CI cannot validate), the correct path is a `fix/CK-XXX_description` branch with a PR — not a direct push to `main`. The hotfix branch type exists precisely for this scenario.
+
+**If the contributor base grows** and a proper review workflow becomes feasible, remove the bypass actor entirely from both rulesets.
+
+**Deletion protection on feature branches is intentionally omitted.** Feature branches are temporary: they are created for a single feature and deleted after the feature PR merges to `main`. Applying the `deletion` rule would block this routine cleanup and, crucially, would prevent deletion even by the org admin (since the bypass is `pull_request`-only and deletion is not a PR operation). Traceability of completed work is preserved by the merge commit on `main` and the closed GitHub Issues, not by retaining the branch ref.
+
+**`do_not_enforce_on_create: true` on `required_status_checks` for feature branches.** This setting exempts the initial creation of a `feature/**/branch` ref from the status-check requirement. Without it, GitHub blocks `git push origin feature/CK-XXX/branch` even when the branch points to a commit that already passed CI on `main`, because the checks have not run in the context of the new ref. This is a GitHub platform limitation, not a gap in coverage: no new code is introduced when creating a branch from `main`. The setting does not affect PRs — any task or design branch PR targeting `feature/**/branch` is still required to have all three status checks pass before merging.
+
 ### Two-layer CI
 
 PRs targeting `feature/**/branch` run a fast subset of checks (unit tests only, no Testcontainers, no ADR consistency check). PRs targeting `main` run the full suite.

--- a/infra/rulesets/feature-branch.json
+++ b/infra/rulesets/feature-branch.json
@@ -11,9 +11,6 @@
   },
   "rules": [
     {
-      "type": "deletion"
-    },
-    {
       "type": "non_fast_forward"
     },
     {
@@ -34,7 +31,8 @@
           {"context": "Backend coverage check (unit)"},
           {"context": "Frontend coverage check"}
         ],
-        "strict_required_status_checks_policy": false
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": true
       }
     }
   ]


### PR DESCRIPTION
Brings `feature/CK-93/branch` up to date with `main` (missing commit `bc0e743` from PR #94).

This unblocks PR #103 (design branch), whose CI check compares against `origin/feature/CK-93/branch` and was detecting changes outside `docs/specs/` as a false positive.

No spec required — sync only.