### PR TITLE
[CK-93] T-02 — database schema: user_profiles

### DIFF
--- a/db/migrations/003_create_user_profiles.down.sql
+++ b/db/migrations/003_create_user_profiles.down.sql
@@ -1,0 +1,3 @@
+-- Migration 003 (down): drop the user_profiles table.
+
+DROP TABLE IF EXISTS user_profiles;

--- a/db/migrations/003_create_user_profiles.up.sql
+++ b/db/migrations/003_create_user_profiles.up.sql
@@ -1,0 +1,20 @@
+-- Migration 003 (up): create the user_profiles table and backfill existing users.
+
+CREATE TABLE user_profiles (
+    user_id       UUID         PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    display_name  VARCHAR(255) NOT NULL,
+    city          VARCHAR(255),
+    region        VARCHAR(10),
+    country       VARCHAR(2),
+    gender        VARCHAR(10)  CHECK (gender IN ('male', 'female')),
+    date_of_birth DATE,
+    category      VARCHAR(10)  CHECK (category IN ('first','second','third','fourth','fifth')),
+    preferences   JSONB        NOT NULL DEFAULT '{}',
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Backfill profiles for users created before this feature.
+INSERT INTO user_profiles (user_id, display_name)
+SELECT id, name FROM users
+ON CONFLICT (user_id) DO NOTHING;

--- a/db/schema/user_profiles.sql
+++ b/db/schema/user_profiles.sql
@@ -1,0 +1,17 @@
+-- user_profiles: extended profile for each user.
+-- Each row is owned by exactly one user (1:1 relationship).
+-- Preferences are stored as JSONB to allow schema-free sport-specific settings.
+
+CREATE TABLE user_profiles (
+    user_id       UUID         PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    display_name  VARCHAR(255) NOT NULL,
+    city          VARCHAR(255),
+    region        VARCHAR(10),
+    country       VARCHAR(2),
+    gender        VARCHAR(10)  CHECK (gender IN ('male', 'female')),
+    date_of_birth DATE,
+    category      VARCHAR(10)  CHECK (category IN ('first','second','third','fourth','fifth')),
+    preferences   JSONB        NOT NULL DEFAULT '{}',
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary

- Adds `db/schema/user_profiles.sql` — reference table definition for the `user_profiles` table.
- Adds `db/migrations/003_create_user_profiles.up.sql` — creates the `user_profiles` table and backfills existing users from `users`.
- Adds `db/migrations/003_create_user_profiles.down.sql` — drops the `user_profiles` table.

The schema matches the spec in `02_architecture.md` exactly: UUID primary key referencing `users(id)` with `ON DELETE CASCADE`, all optional profile fields with appropriate constraints, and a JSONB `preferences` column defaulting to `{}`.

## Test plan

- [ ] Run `make db-migrate` against a PostgreSQL instance that already contains the `users` table — verify `user_profiles` is created and existing users are backfilled.
- [ ] Run `make db-rollback` — verify `user_profiles` is dropped cleanly.
- [ ] Re-run `make db-migrate` — verify the migration is idempotent (backfill uses `ON CONFLICT DO NOTHING`).

Closes #97
Spec: docs/specs/FEATURE_user_profile/

🤖 Generated with [Claude Code](https://claude.com/claude-code)