### PR TITLE
[CK-93] T-03 — infrastructure: PostgreSQL ProfileRepository

### DIFF
--- a/api/internal/infrastructure/postgres/integration_test.go
+++ b/api/internal/infrastructure/postgres/integration_test.go
@@ -7,6 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,42 +68,32 @@ func TestMain(m *testing.M) {
 }
 
 func applyMigrations(ctx context.Context, db *pgxpool.Pool) error {
-	ddl := `
-	CREATE TABLE IF NOT EXISTS users (
-		id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-		email       VARCHAR(255) NOT NULL UNIQUE,
-		name        VARCHAR(255) NOT NULL,
-		role        VARCHAR(50)  NOT NULL DEFAULT 'user'
-		                         CHECK (role IN ('admin', 'user')),
-		provider    VARCHAR(50)  NOT NULL
-		                         CHECK (provider IN ('google', 'github', 'pat')),
-		provider_id VARCHAR(255) NOT NULL,
-		created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-		updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-		UNIQUE (provider, provider_id)
-	);
-	CREATE TABLE IF NOT EXISTS personal_access_tokens (
-		id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-		key_hash    VARCHAR(255) NOT NULL,
-		salt        VARCHAR(255) NOT NULL,
-		expires_at  TIMESTAMPTZ,
-		created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
-	);
-	CREATE TABLE IF NOT EXISTS user_profiles (
-		user_id       UUID         PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
-		display_name  VARCHAR(255) NOT NULL,
-		city          VARCHAR(255),
-		region        VARCHAR(10),
-		country       VARCHAR(2),
-		gender        VARCHAR(10)  CHECK (gender IN ('male', 'female')),
-		date_of_birth DATE,
-		category      VARCHAR(10)  CHECK (category IN ('first','second','third','fourth','fifth')),
-		preferences   JSONB        NOT NULL DEFAULT '{}',
-		created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-		updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
-	);`
-	_, err := db.Exec(ctx, ddl)
-	return err
+	// Resolve db/migrations relative to this package (api/internal/infrastructure/postgres/).
+	migrationsDir := filepath.Join("..", "..", "..", "..", "db", "migrations")
+
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		return fmt.Errorf("read migrations dir: %w", err)
+	}
+
+	var upFiles []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".up.sql") {
+			upFiles = append(upFiles, e.Name())
+		}
+	}
+	sort.Strings(upFiles)
+
+	for _, name := range upFiles {
+		sql, err := os.ReadFile(filepath.Join(migrationsDir, name))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", name, err)
+		}
+		if _, err := db.Exec(ctx, string(sql)); err != nil {
+			return fmt.Errorf("apply %s: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func truncate(t *testing.T) {

--- a/api/internal/infrastructure/postgres/integration_test.go
+++ b/api/internal/infrastructure/postgres/integration_test.go
@@ -85,6 +85,19 @@ func applyMigrations(ctx context.Context, db *pgxpool.Pool) error {
 		salt        VARCHAR(255) NOT NULL,
 		expires_at  TIMESTAMPTZ,
 		created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+	);
+	CREATE TABLE IF NOT EXISTS user_profiles (
+		user_id       UUID         PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+		display_name  VARCHAR(255) NOT NULL,
+		city          VARCHAR(255),
+		region        VARCHAR(10),
+		country       VARCHAR(2),
+		gender        VARCHAR(10)  CHECK (gender IN ('male', 'female')),
+		date_of_birth DATE,
+		category      VARCHAR(10)  CHECK (category IN ('first','second','third','fourth','fifth')),
+		preferences   JSONB        NOT NULL DEFAULT '{}',
+		created_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+		updated_at    TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 	);`
 	_, err := db.Exec(ctx, ddl)
 	return err

--- a/api/internal/infrastructure/postgres/profile_repository.go
+++ b/api/internal/infrastructure/postgres/profile_repository.go
@@ -1,0 +1,296 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/courtknights/courtknights/internal/domain/ckerrors"
+	"github.com/courtknights/courtknights/internal/domain/profile"
+)
+
+// ProfileRepository implements profile.ProfileRepository using PostgreSQL.
+type ProfileRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewProfileRepository returns a ProfileRepository backed by the given connection pool.
+func NewProfileRepository(db *pgxpool.Pool) *ProfileRepository {
+	return &ProfileRepository{db: db}
+}
+
+// EnsureExists implements profile.ProfileRepository.
+// It inserts a new profile row for the given user if one does not already exist.
+// The call is idempotent: if a profile already exists for the user it is a no-op.
+func (r *ProfileRepository) EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error {
+	const q = `
+		INSERT INTO user_profiles (user_id, display_name)
+		VALUES ($1, $2)
+		ON CONFLICT (user_id) DO NOTHING`
+
+	_, err := r.db.Exec(ctx, q, userID, displayName)
+	if err != nil {
+		return fmt.Errorf("postgres: EnsureExists profile: %w", err)
+	}
+	return nil
+}
+
+// FindByUserID implements profile.ProfileRepository.
+// Returns ckerrors.ErrProfileNotFound when no profile exists for the given user.
+func (r *ProfileRepository) FindByUserID(ctx context.Context, userID uuid.UUID) (*profile.Profile, error) {
+	const q = `
+		SELECT user_id, display_name, city, region, country, gender, date_of_birth,
+		       category, preferences, created_at, updated_at
+		FROM user_profiles
+		WHERE user_id = $1`
+
+	row := r.db.QueryRow(ctx, q, userID)
+	p, err := scanProfile(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("postgres: FindByUserID profile: %w", ckerrors.ErrProfileNotFound)
+		}
+		return nil, fmt.Errorf("postgres: FindByUserID profile: %w", err)
+	}
+	return p, nil
+}
+
+// Update implements profile.ProfileRepository.
+// Only non-nil patch fields are applied. Returns the updated profile row.
+func (r *ProfileRepository) Update(ctx context.Context, userID uuid.UUID, patch profile.ProfilePatch) (*profile.Profile, error) {
+	setClauses := make([]string, 0, 8)
+	args := make([]any, 0, 9)
+	idx := 1
+
+	if patch.DisplayName != nil {
+		setClauses = append(setClauses, fmt.Sprintf("display_name = $%d", idx))
+		args = append(args, *patch.DisplayName)
+		idx++
+	}
+	if patch.City != nil {
+		setClauses = append(setClauses, fmt.Sprintf("city = $%d", idx))
+		args = append(args, *patch.City)
+		idx++
+	}
+	if patch.Region != nil {
+		setClauses = append(setClauses, fmt.Sprintf("region = $%d", idx))
+		args = append(args, *patch.Region)
+		idx++
+	}
+	if patch.Country != nil {
+		setClauses = append(setClauses, fmt.Sprintf("country = $%d", idx))
+		args = append(args, *patch.Country)
+		idx++
+	}
+	if patch.Gender != nil {
+		setClauses = append(setClauses, fmt.Sprintf("gender = $%d", idx))
+		args = append(args, *patch.Gender)
+		idx++
+	}
+	if patch.DateOfBirth != nil {
+		setClauses = append(setClauses, fmt.Sprintf("date_of_birth = $%d", idx))
+		args = append(args, *patch.DateOfBirth)
+		idx++
+	}
+	if patch.Category != nil {
+		setClauses = append(setClauses, fmt.Sprintf("category = $%d", idx))
+		args = append(args, *patch.Category)
+		idx++
+	}
+	if patch.Preferences != nil {
+		prefsJSON, err := json.Marshal(patch.Preferences)
+		if err != nil {
+			return nil, fmt.Errorf("postgres: Update profile marshal preferences: %w", err)
+		}
+		setClauses = append(setClauses, fmt.Sprintf("preferences = $%d", idx))
+		args = append(args, prefsJSON)
+		idx++
+	}
+
+	if len(setClauses) == 0 {
+		// Nothing to update — return the current profile unchanged.
+		return r.FindByUserID(ctx, userID)
+	}
+
+	// Always update updated_at.
+	setClauses = append(setClauses, fmt.Sprintf("updated_at = $%d", idx))
+	args = append(args, time.Now().UTC())
+	idx++
+
+	// Append userID as the final argument for the WHERE clause.
+	args = append(args, userID)
+
+	q := buildUpdateQuery(setClauses, idx)
+
+	row := r.db.QueryRow(ctx, q, args...)
+	p, err := scanProfile(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("postgres: Update profile: %w", ckerrors.ErrProfileNotFound)
+		}
+		return nil, fmt.Errorf("postgres: Update profile: %w", err)
+	}
+	return p, nil
+}
+
+// buildUpdateQuery assembles the UPDATE statement from the pre-built SET clauses.
+// idx is the next available parameter index (used for the WHERE clause).
+func buildUpdateQuery(setClauses []string, whereIdx int) string {
+	q := "UPDATE user_profiles SET "
+	for i, clause := range setClauses {
+		if i > 0 {
+			q += ", "
+		}
+		q += clause
+	}
+	q += fmt.Sprintf(`
+		WHERE user_id = $%d
+		RETURNING user_id, display_name, city, region, country, gender, date_of_birth,
+		          category, preferences, created_at, updated_at`, whereIdx)
+	return q
+}
+
+// List implements profile.ProfileRepository.
+// Returns a paginated list of profiles joined with the users table, ordered by display_name ASC.
+// The second return value is the total count of profiles across all pages.
+func (r *ProfileRepository) List(ctx context.Context, params profile.ListParams) ([]*profile.ProfileListItem, int64, error) {
+	offset := (params.Page - 1) * params.PageSize
+
+	const q = `
+		SELECT
+			u.id,
+			p.display_name,
+			p.city,
+			p.region,
+			p.country,
+			p.gender,
+			p.category,
+			COUNT(*) OVER() AS total_count
+		FROM users u
+		JOIN user_profiles p ON p.user_id = u.id
+		ORDER BY p.display_name ASC
+		LIMIT $1 OFFSET $2`
+
+	rows, err := r.db.Query(ctx, q, params.PageSize, offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("postgres: List profiles: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*profile.ProfileListItem
+	var totalCount int64
+
+	for rows.Next() {
+		item, count, err := scanProfileListItem(rows)
+		if err != nil {
+			return nil, 0, fmt.Errorf("postgres: List profiles scan: %w", err)
+		}
+		if totalCount == 0 {
+			totalCount = count
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("postgres: List profiles rows: %w", err)
+	}
+
+	if items == nil {
+		items = []*profile.ProfileListItem{}
+	}
+
+	return items, totalCount, nil
+}
+
+// scanProfile reads a profile row from a pgx.Row.
+func scanProfile(row pgx.Row) (*profile.Profile, error) {
+	var p profile.Profile
+	var gender *string
+	var category *string
+	var prefsJSON []byte
+	var dateOfBirth *time.Time
+	var createdAt, updatedAt time.Time
+
+	err := row.Scan(
+		&p.UserID,
+		&p.DisplayName,
+		&p.City,
+		&p.Region,
+		&p.Country,
+		&gender,
+		&dateOfBirth,
+		&category,
+		&prefsJSON,
+		&createdAt,
+		&updatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if gender != nil {
+		g := profile.Gender(*gender)
+		p.Gender = &g
+	}
+	if category != nil {
+		c := profile.Category(*category)
+		p.Category = &c
+	}
+	if dateOfBirth != nil {
+		p.DateOfBirth = dateOfBirth
+	}
+
+	if len(prefsJSON) > 0 {
+		if err := json.Unmarshal(prefsJSON, &p.Preferences); err != nil {
+			return nil, fmt.Errorf("unmarshal preferences: %w", err)
+		}
+	}
+
+	p.CreatedAt = createdAt
+	p.UpdatedAt = updatedAt
+
+	return &p, nil
+}
+
+// scanProfileListItem reads a profile list row from pgx.Rows (includes the window count column).
+func scanProfileListItem(rows pgx.Rows) (*profile.ProfileListItem, int64, error) {
+	var item profile.ProfileListItem
+	var id uuid.UUID
+	var displayName string
+	var gender *string
+	var category *string
+	var totalCount int64
+
+	err := rows.Scan(
+		&id,
+		&displayName,
+		&item.City,
+		&item.Region,
+		&item.Country,
+		&gender,
+		&category,
+		&totalCount,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	item.ID = &id
+	item.DisplayName = &displayName
+
+	if gender != nil {
+		g := profile.Gender(*gender)
+		item.Gender = &g
+	}
+	if category != nil {
+		c := profile.Category(*category)
+		item.Category = &c
+	}
+
+	return &item, totalCount, nil
+}

--- a/api/internal/infrastructure/postgres/profile_repository_integration_test.go
+++ b/api/internal/infrastructure/postgres/profile_repository_integration_test.go
@@ -1,0 +1,428 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/courtknights/courtknights/internal/domain/ckerrors"
+	"github.com/courtknights/courtknights/internal/domain/profile"
+	"github.com/courtknights/courtknights/internal/domain/user"
+)
+
+// createTestUser inserts a user into the test DB and returns its ID.
+func createTestUser(t *testing.T, name string) uuid.UUID {
+	t.Helper()
+	repo := NewUserRepository(testDB)
+	u, err := repo.Upsert(context.Background(), &user.User{
+		Email:      fmt.Sprintf("%s@example.com", uuid.New().String()),
+		Name:       name,
+		Role:       user.RoleUser,
+		Provider:   user.ProviderGoogle,
+		ProviderID: uuid.New().String(),
+	})
+	if err != nil {
+		t.Fatalf("createTestUser: Upsert: %v", err)
+	}
+	return u.ID
+}
+
+// ptr returns a pointer to the given value (generic helper).
+func ptr[T any](v T) *T { return &v }
+
+// ---- ProfileRepository: EnsureExists ----
+
+// PR-01: Creates a profile for a new user.
+func TestProfileRepository_EnsureExists_CreatesProfile(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Alice")
+	repo := NewProfileRepository(testDB)
+
+	err := repo.EnsureExists(context.Background(), userID, "Alice")
+	if err != nil {
+		t.Fatalf("EnsureExists: %v", err)
+	}
+
+	p, err := repo.FindByUserID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("FindByUserID after EnsureExists: %v", err)
+	}
+	if p.DisplayName != "Alice" {
+		t.Errorf("display_name: got %q, want %q", p.DisplayName, "Alice")
+	}
+	if p.UserID != userID {
+		t.Errorf("user_id mismatch: got %v, want %v", p.UserID, userID)
+	}
+}
+
+// PR-02: No-op when profile already exists.
+func TestProfileRepository_EnsureExists_NoOpWhenAlreadyExists(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Bob")
+	repo := NewProfileRepository(testDB)
+
+	if err := repo.EnsureExists(context.Background(), userID, "Bob"); err != nil {
+		t.Fatalf("first EnsureExists: %v", err)
+	}
+
+	// Update the display name directly so we can detect if EnsureExists overwrites it.
+	_, err := testDB.Exec(context.Background(),
+		`UPDATE user_profiles SET display_name = 'Bob Updated' WHERE user_id = $1`, userID)
+	if err != nil {
+		t.Fatalf("update display_name: %v", err)
+	}
+
+	// Second EnsureExists must be a no-op.
+	if err := repo.EnsureExists(context.Background(), userID, "Bob"); err != nil {
+		t.Fatalf("second EnsureExists: %v", err)
+	}
+
+	p, err := repo.FindByUserID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("FindByUserID: %v", err)
+	}
+	if p.DisplayName != "Bob Updated" {
+		t.Errorf("expected display_name unchanged at %q, got %q", "Bob Updated", p.DisplayName)
+	}
+}
+
+// PR-03: Non-existent user ID causes FK violation error.
+func TestProfileRepository_EnsureExists_FKViolationForUnknownUser(t *testing.T) {
+	truncate(t)
+	repo := NewProfileRepository(testDB)
+
+	err := repo.EnsureExists(context.Background(), uuid.New(), "Ghost")
+	if err == nil {
+		t.Fatal("expected FK violation error, got nil")
+	}
+}
+
+// ---- ProfileRepository: FindByUserID ----
+
+// PR-04: Returns profile for existing user.
+func TestProfileRepository_FindByUserID_ReturnsProfile(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Carol")
+	repo := NewProfileRepository(testDB)
+
+	if err := repo.EnsureExists(context.Background(), userID, "Carol"); err != nil {
+		t.Fatalf("EnsureExists: %v", err)
+	}
+
+	p, err := repo.FindByUserID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("FindByUserID: %v", err)
+	}
+	if p.UserID != userID {
+		t.Errorf("user_id: got %v, want %v", p.UserID, userID)
+	}
+	if p.DisplayName != "Carol" {
+		t.Errorf("display_name: got %q, want %q", p.DisplayName, "Carol")
+	}
+}
+
+// PR-05: Returns ErrProfileNotFound when no profile exists.
+func TestProfileRepository_FindByUserID_NotFound(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Dave")
+	repo := NewProfileRepository(testDB)
+
+	_, err := repo.FindByUserID(context.Background(), userID)
+	if err == nil {
+		t.Fatal("expected ErrProfileNotFound, got nil")
+	}
+	if !errors.Is(err, ckerrors.ErrProfileNotFound) {
+		t.Errorf("expected ErrProfileNotFound, got: %v", err)
+	}
+}
+
+// PR-06: All nullable fields are null when only display_name is set.
+func TestProfileRepository_FindByUserID_NullableFieldsAreNil(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Eve")
+	repo := NewProfileRepository(testDB)
+
+	if err := repo.EnsureExists(context.Background(), userID, "Eve"); err != nil {
+		t.Fatalf("EnsureExists: %v", err)
+	}
+
+	p, err := repo.FindByUserID(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("FindByUserID: %v", err)
+	}
+	if p.City != nil {
+		t.Errorf("expected City nil, got %v", p.City)
+	}
+	if p.Region != nil {
+		t.Errorf("expected Region nil, got %v", p.Region)
+	}
+	if p.Country != nil {
+		t.Errorf("expected Country nil, got %v", p.Country)
+	}
+	if p.Gender != nil {
+		t.Errorf("expected Gender nil, got %v", p.Gender)
+	}
+	if p.DateOfBirth != nil {
+		t.Errorf("expected DateOfBirth nil, got %v", p.DateOfBirth)
+	}
+	if p.Category != nil {
+		t.Errorf("expected Category nil, got %v", p.Category)
+	}
+}
+
+// ---- ProfileRepository: Update ----
+
+// PR-07: Partial update — only display_name; other fields unchanged.
+func TestProfileRepository_Update_PartialUpdateDisplayName(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Frank")
+	repo := NewProfileRepository(testDB)
+
+	if err := repo.EnsureExists(context.Background(), userID, "Frank"); err != nil {
+		t.Fatalf("EnsureExists: %v", err)
+	}
+
+	// Set city first so we can confirm it is unchanged after update.
+	city := "Madrid"
+	_, err := repo.Update(context.Background(), userID, profile.ProfilePatch{City: &city})
+	if err != nil {
+		t.Fatalf("pre-update city: %v", err)
+	}
+
+	updated, err := repo.Update(context.Background(), userID, profile.ProfilePatch{
+		DisplayName: ptr("Frank Updated"),
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.DisplayName != "Frank Updated" {
+		t.Errorf("display_name: got %q, want %q", updated.DisplayName, "Frank Updated")
+	}
+	if updated.City == nil || *updated.City != "Madrid" {
+		t.Errorf("city should remain %q, got %v", "Madrid", updated.City)
+	}
+}
+
+// PR-08: Update all fields at once.
+func TestProfileRepository_Update_AllFields(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Grace")
+	repo := NewProfileRepository(testDB)
+
+	if err := repo.EnsureExists(context.Background(), userID, "Grace"); err != nil {
+		t.Fatalf("EnsureExists: %v", err)
+	}
+
+	dob := time.Date(1990, 5, 14, 0, 0, 0, 0, time.UTC)
+	patch := profile.ProfilePatch{
+		DisplayName: ptr("Grace Full"),
+		City:        ptr("Barcelona"),
+		Region:      ptr("ES-CT"),
+		Country:     ptr("ES"),
+		Gender:      ptr(profile.GenderFemale),
+		DateOfBirth: &dob,
+		Category:    ptr(profile.CategoryThird),
+		Preferences: &profile.Preferences{
+			CourtSide:  ptr(profile.CourtSideDrive),
+			Handedness: ptr(profile.HandednessRight),
+		},
+	}
+
+	updated, err := repo.Update(context.Background(), userID, patch)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if updated.DisplayName != "Grace Full" {
+		t.Errorf("display_name: got %q", updated.DisplayName)
+	}
+	if updated.City == nil || *updated.City != "Barcelona" {
+		t.Errorf("city: got %v", updated.City)
+	}
+	if updated.Region == nil || *updated.Region != "ES-CT" {
+		t.Errorf("region: got %v", updated.Region)
+	}
+	if updated.Country == nil || *updated.Country != "ES" {
+		t.Errorf("country: got %v", updated.Country)
+	}
+	if updated.Gender == nil || *updated.Gender != profile.GenderFemale {
+		t.Errorf("gender: got %v", updated.Gender)
+	}
+	if updated.DateOfBirth == nil {
+		t.Fatal("expected DateOfBirth set")
+	}
+	// Compare date only (DB stores DATE, not full timestamp).
+	gotDOB := updated.DateOfBirth.UTC()
+	if gotDOB.Year() != 1990 || gotDOB.Month() != 5 || gotDOB.Day() != 14 {
+		t.Errorf("date_of_birth: got %v, want 1990-05-14", gotDOB)
+	}
+	if updated.Category == nil || *updated.Category != profile.CategoryThird {
+		t.Errorf("category: got %v", updated.Category)
+	}
+	if updated.Preferences.CourtSide == nil || *updated.Preferences.CourtSide != profile.CourtSideDrive {
+		t.Errorf("preferences.court_side: got %v", updated.Preferences.CourtSide)
+	}
+	if updated.Preferences.Handedness == nil || *updated.Preferences.Handedness != profile.HandednessRight {
+		t.Errorf("preferences.handedness: got %v", updated.Preferences.Handedness)
+	}
+}
+
+// PR-09: Update preferences only; other fields unchanged.
+func TestProfileRepository_Update_PreferencesOnly(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Henry")
+	repo := NewProfileRepository(testDB)
+
+	if err := repo.EnsureExists(context.Background(), userID, "Henry"); err != nil {
+		t.Fatalf("EnsureExists: %v", err)
+	}
+
+	// First set a city so we can confirm it remains unchanged.
+	_, err := repo.Update(context.Background(), userID, profile.ProfilePatch{City: ptr("Seville")})
+	if err != nil {
+		t.Fatalf("pre-update city: %v", err)
+	}
+
+	updated, err := repo.Update(context.Background(), userID, profile.ProfilePatch{
+		Preferences: &profile.Preferences{CourtSide: ptr(profile.CourtSideDrive)},
+	})
+	if err != nil {
+		t.Fatalf("Update preferences: %v", err)
+	}
+	if updated.Preferences.CourtSide == nil || *updated.Preferences.CourtSide != profile.CourtSideDrive {
+		t.Errorf("preferences.court_side: got %v", updated.Preferences.CourtSide)
+	}
+	if updated.City == nil || *updated.City != "Seville" {
+		t.Errorf("city should remain %q, got %v", "Seville", updated.City)
+	}
+}
+
+// PR-10: Update non-existent profile returns ErrProfileNotFound.
+func TestProfileRepository_Update_ProfileNotFound(t *testing.T) {
+	truncate(t)
+	userID := createTestUser(t, "Ivan")
+	repo := NewProfileRepository(testDB)
+
+	// Do NOT call EnsureExists — no profile exists.
+	_, err := repo.Update(context.Background(), userID, profile.ProfilePatch{
+		DisplayName: ptr("Ivan Updated"),
+	})
+	if err == nil {
+		t.Fatal("expected error for non-existent profile, got nil")
+	}
+	if !errors.Is(err, ckerrors.ErrProfileNotFound) {
+		t.Errorf("expected ErrProfileNotFound, got: %v", err)
+	}
+}
+
+// ---- ProfileRepository: List ----
+
+// createProfilesForList inserts N users with profiles for list tests.
+// Display names are generated so they sort predictably: "User 01", "User 02", …
+func createProfilesForList(t *testing.T, n int) {
+	t.Helper()
+	repo := NewProfileRepository(testDB)
+	userRepo := NewUserRepository(testDB)
+
+	for i := 1; i <= n; i++ {
+		name := fmt.Sprintf("User %02d", i)
+		u, err := userRepo.Upsert(context.Background(), &user.User{
+			Email:      fmt.Sprintf("list-user-%d@example.com", i),
+			Name:       name,
+			Role:       user.RoleUser,
+			Provider:   user.ProviderGoogle,
+			ProviderID: fmt.Sprintf("google-list-%d", i),
+		})
+		if err != nil {
+			t.Fatalf("Upsert user %d: %v", i, err)
+		}
+		if err := repo.EnsureExists(context.Background(), u.ID, name); err != nil {
+			t.Fatalf("EnsureExists user %d: %v", i, err)
+		}
+	}
+}
+
+// PR-11: Returns all profiles ordered by display_name ASC.
+func TestProfileRepository_List_OrderedByDisplayName(t *testing.T) {
+	truncate(t)
+	createProfilesForList(t, 3)
+	repo := NewProfileRepository(testDB)
+
+	items, total, err := repo.List(context.Background(), profile.ListParams{Page: 1, PageSize: 100})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("total: got %d, want 3", total)
+	}
+	if len(items) != 3 {
+		t.Fatalf("items length: got %d, want 3", len(items))
+	}
+	// Verify ordering: "User 01" < "User 02" < "User 03"
+	for i := 0; i < len(items)-1; i++ {
+		if *items[i].DisplayName >= *items[i+1].DisplayName {
+			t.Errorf("ordering violation at index %d: %q >= %q",
+				i, *items[i].DisplayName, *items[i+1].DisplayName)
+		}
+	}
+}
+
+// PR-12: Pagination — first page of 2, 5 profiles in DB.
+func TestProfileRepository_List_FirstPage(t *testing.T) {
+	truncate(t)
+	createProfilesForList(t, 5)
+	repo := NewProfileRepository(testDB)
+
+	items, total, err := repo.List(context.Background(), profile.ListParams{Page: 1, PageSize: 2})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("total: got %d, want 5", total)
+	}
+	if len(items) != 2 {
+		t.Errorf("items length: got %d, want 2", len(items))
+	}
+}
+
+// PR-13: Pagination — last page (page 3 of 3), 5 profiles in DB.
+func TestProfileRepository_List_LastPage(t *testing.T) {
+	truncate(t)
+	createProfilesForList(t, 5)
+	repo := NewProfileRepository(testDB)
+
+	items, total, err := repo.List(context.Background(), profile.ListParams{Page: 3, PageSize: 2})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("total: got %d, want 5", total)
+	}
+	if len(items) != 1 {
+		t.Errorf("items length: got %d, want 1", len(items))
+	}
+}
+
+// PR-14: Page beyond total returns empty slice but correct total.
+func TestProfileRepository_List_PageBeyondTotal(t *testing.T) {
+	truncate(t)
+	createProfilesForList(t, 5)
+	repo := NewProfileRepository(testDB)
+
+	items, total, err := repo.List(context.Background(), profile.ListParams{Page: 10, PageSize: 2})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("total: got %d, want 5", total)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected empty slice, got %d items", len(items))
+	}
+}

--- a/docs/testing/regression_map.md
+++ b/docs/testing/regression_map.md
@@ -3,7 +3,7 @@
 Tracks dependencies between features. Update this file every time a feature is merged.
 When a feature is modified, all dependent features in this map must have their tests re-run.
 
-- **Last updated:** 2026-04-02
+- **Last updated:** 2026-04-03
 
 ---
 
@@ -36,3 +36,6 @@ When a feature is modified, all dependent features in this map must have their t
 | FEATURE_ci_checks / TASK-005 | `check_adr_consistency.py` — AI-assisted ADR consistency check via claude-sonnet-4-6 (BLOCKING/WARNING violations, adr-change label) | FEATURE_ci_checks / TASK-001 | FEATURE_ci_checks / TASK-006 |
 | FEATURE_ci_checks / TASK-006 | `.github/workflows/ci.yml` — GitHub Actions workflow orchestrating all 4 CI checks as parallel jobs on PRs to main | FEATURE_ci_checks / TASK-002..005 | FEATURE_branching_workflow |
 | FEATURE_branching_workflow | ADR-012 hierarchical branching model, two-layer CI, design-branch content check, GitHub rulesets, CONTRIBUTING.md, README.md | FEATURE_ci_checks / TASK-006, FEATURE_repo_workspaces | — |
+| FEATURE_user_profile / T-01 | `profile` domain entities (`Profile`, `Preferences`, enums), `ProfileRepository` interface, `ValidateLocation`, `ckerrors.ErrProfileNotFound` | — | FEATURE_user_profile / T-03..T-07 |
+| FEATURE_user_profile / T-02 | `user_profiles` DB migration (003) + schema definition | FEATURE_authentication / postgres | FEATURE_user_profile / T-03 |
+| FEATURE_user_profile / T-03 | `ProfileRepository` PostgreSQL implementation (`EnsureExists`, `FindByUserID`, `Update`, `List`) | FEATURE_user_profile / T-01, T-02, FEATURE_authentication / postgres | FEATURE_user_profile / T-05 |


### PR DESCRIPTION
## Summary

- Implements `profile.ProfileRepository` in `api/internal/infrastructure/postgres/profile_repository.go` with four methods: `EnsureExists`, `FindByUserID`, `Update`, and `List`
- Adds integration tests (build tag `integration`) covering all 14 cases from `04_tests.md` (PR-01 through PR-14) in `profile_repository_integration_test.go`
- Extends `applyMigrations` in `integration_test.go` with the `user_profiles` table DDL so integration tests have the correct schema
- Updates `docs/testing/regression_map.md` to record T-01, T-02, and T-03 dependency entries

## Implementation notes

- `EnsureExists`: `INSERT … ON CONFLICT (user_id) DO NOTHING` — fully idempotent
- `FindByUserID`: simple SELECT by `user_id`; wraps `pgx.ErrNoRows` as `ckerrors.ErrProfileNotFound`
- `Update`: builds the SET clause dynamically from non-nil patch fields; returns `ErrProfileNotFound` when the WHERE clause matches zero rows
- `List`: JOIN `users` with `user_profiles`; `COUNT(*) OVER()` window function for total count; ORDER BY `display_name ASC`; LIMIT/OFFSET from `ListParams`

## Test plan

- [ ] `make test` passes (unit tests, no Docker required)
- [ ] `make test-int` passes (integration tests, requires Docker)
- [ ] All PR-01 through PR-14 test cases are covered

Closes #98
Spec: docs/specs/FEATURE_user_profile/