### PR TITLE
[CK-93] T-04 — application: ProfileManager

### DIFF
--- a/api/internal/application/profile/manager.go
+++ b/api/internal/application/profile/manager.go
@@ -1,0 +1,81 @@
+// Package profile provides the application layer for profile management.
+// It implements business logic that sits between the HTTP layer and the
+// domain/infrastructure layers.
+package profile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/courtknights/courtknights/internal/domain/profile"
+)
+
+// ProfileManager is the entry point for all profile-related operations.
+// It validates input, delegates persistence to the repository, and returns
+// domain objects to the HTTP layer.
+type ProfileManager interface {
+	// EnsureExists creates a profile for the given user if one does not already exist.
+	// It is idempotent and safe to call on every login.
+	EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error
+
+	// GetByUserID returns the profile for the given user.
+	// Returns ckerrors.ErrProfileNotFound if no profile exists.
+	GetByUserID(ctx context.Context, userID uuid.UUID) (*profile.Profile, error)
+
+	// Update validates the patch and applies it to the user's profile.
+	// If Country or Region are non-nil, location codes are validated before
+	// the repository is called. Returns a validation error without calling
+	// the repository if any code is invalid.
+	Update(ctx context.Context, userID uuid.UUID, patch profile.ProfilePatch) (*profile.Profile, error)
+
+	// List returns a paginated list of profiles joined with basic user data.
+	List(ctx context.Context, params profile.ListParams) ([]*profile.ProfileListItem, int64, error)
+}
+
+type profileManager struct {
+	profiles profile.ProfileRepository
+}
+
+// NewProfileManager returns a ProfileManager backed by the given repository.
+func NewProfileManager(repo profile.ProfileRepository) ProfileManager {
+	return &profileManager{profiles: repo}
+}
+
+func (m *profileManager) EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error {
+	if err := m.profiles.EnsureExists(ctx, userID, displayName); err != nil {
+		return fmt.Errorf("profile manager: EnsureExists: %w", err)
+	}
+	return nil
+}
+
+func (m *profileManager) GetByUserID(ctx context.Context, userID uuid.UUID) (*profile.Profile, error) {
+	p, err := m.profiles.FindByUserID(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("profile manager: GetByUserID: %w", err)
+	}
+	return p, nil
+}
+
+func (m *profileManager) Update(ctx context.Context, userID uuid.UUID, patch profile.ProfilePatch) (*profile.Profile, error) {
+	if patch.Country != nil || patch.Region != nil {
+		if err := profile.ValidateLocation(patch.Country, patch.Region); err != nil {
+			return nil, fmt.Errorf("profile manager: Update: %w", err)
+		}
+	}
+
+	p, err := m.profiles.Update(ctx, userID, patch)
+	if err != nil {
+		return nil, fmt.Errorf("profile manager: Update: %w", err)
+	}
+	return p, nil
+}
+
+func (m *profileManager) List(ctx context.Context, params profile.ListParams) ([]*profile.ProfileListItem, int64, error) {
+	items, total, err := m.profiles.List(ctx, params)
+	if err != nil {
+		return nil, 0, fmt.Errorf("profile manager: List: %w", err)
+	}
+	return items, total, nil
+}

--- a/api/internal/application/profile/manager_test.go
+++ b/api/internal/application/profile/manager_test.go
@@ -1,0 +1,225 @@
+package profile
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/courtknights/courtknights/internal/domain/ckerrors"
+	"github.com/courtknights/courtknights/internal/domain/profile"
+)
+
+// mockProfileRepository is a testify mock for profile.ProfileRepository.
+type mockProfileRepository struct{ mock.Mock }
+
+func (m *mockProfileRepository) EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error {
+	return m.Called(ctx, userID, displayName).Error(0)
+}
+
+func (m *mockProfileRepository) FindByUserID(ctx context.Context, userID uuid.UUID) (*profile.Profile, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*profile.Profile), args.Error(1)
+}
+
+func (m *mockProfileRepository) Update(ctx context.Context, userID uuid.UUID, patch profile.ProfilePatch) (*profile.Profile, error) {
+	args := m.Called(ctx, userID, patch)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*profile.Profile), args.Error(1)
+}
+
+func (m *mockProfileRepository) List(ctx context.Context, params profile.ListParams) ([]*profile.ProfileListItem, int64, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(int64), args.Error(2)
+	}
+	return args.Get(0).([]*profile.ProfileListItem), args.Get(1).(int64), args.Error(2)
+}
+
+// helpers
+
+func ptr[T any](v T) *T { return &v }
+
+func newTestManager(repo *mockProfileRepository) ProfileManager {
+	return NewProfileManager(repo)
+}
+
+// ---- EnsureExists ----
+
+// PM-01: Delegates to repository successfully.
+func TestProfileManager_EnsureExists_DelegatesToRepo_ReturnsNil(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	repo.On("EnsureExists", mock.Anything, userID, "Alice").Return(nil)
+
+	mgr := newTestManager(repo)
+	err := mgr.EnsureExists(context.Background(), userID, "Alice")
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+// PM-02: Propagates repository error.
+func TestProfileManager_EnsureExists_RepoError_PropagatesError(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	repoErr := errors.New("db error")
+	repo.On("EnsureExists", mock.Anything, userID, "Alice").Return(repoErr)
+
+	mgr := newTestManager(repo)
+	err := mgr.EnsureExists(context.Background(), userID, "Alice")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repoErr)
+	repo.AssertExpectations(t)
+}
+
+// ---- GetByUserID ----
+
+// PM-03: Returns profile from repository.
+func TestProfileManager_GetByUserID_ReturnsProfile(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	expected := &profile.Profile{UserID: userID, DisplayName: "Alice", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	repo.On("FindByUserID", mock.Anything, userID).Return(expected, nil)
+
+	mgr := newTestManager(repo)
+	got, err := mgr.GetByUserID(context.Background(), userID)
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+	repo.AssertExpectations(t)
+}
+
+// PM-04: Propagates ErrProfileNotFound.
+func TestProfileManager_GetByUserID_ProfileNotFound_PropagatesError(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	repo.On("FindByUserID", mock.Anything, userID).Return(nil, ckerrors.ErrProfileNotFound)
+
+	mgr := newTestManager(repo)
+	_, err := mgr.GetByUserID(context.Background(), userID)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ckerrors.ErrProfileNotFound)
+	repo.AssertExpectations(t)
+}
+
+// ---- Update — validation ----
+
+// PM-05: No location fields — skips validation, calls repo.
+func TestProfileManager_Update_NoLocationFields_SkipsValidation_CallsRepo(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	patch := profile.ProfilePatch{DisplayName: ptr("X")}
+	updated := &profile.Profile{UserID: userID, DisplayName: "X", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	repo.On("Update", mock.Anything, userID, patch).Return(updated, nil)
+
+	mgr := newTestManager(repo)
+	got, err := mgr.Update(context.Background(), userID, patch)
+
+	require.NoError(t, err)
+	assert.Equal(t, updated, got)
+	repo.AssertExpectations(t)
+}
+
+// PM-06: Valid country + valid region — calls repo.
+func TestProfileManager_Update_ValidCountryAndRegion_CallsRepo(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	patch := profile.ProfilePatch{Country: ptr("ES"), Region: ptr("ES-MD")}
+	updated := &profile.Profile{UserID: userID, DisplayName: "Alice", Country: ptr("ES"), Region: ptr("ES-MD"), CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	repo.On("Update", mock.Anything, userID, patch).Return(updated, nil)
+
+	mgr := newTestManager(repo)
+	got, err := mgr.Update(context.Background(), userID, patch)
+
+	require.NoError(t, err)
+	assert.Equal(t, updated, got)
+	repo.AssertExpectations(t)
+}
+
+// PM-07: Invalid country — returns error before calling repo.
+func TestProfileManager_Update_InvalidCountry_ReturnsErrorWithoutCallingRepo(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	patch := profile.ProfilePatch{Country: ptr("XX")}
+
+	mgr := newTestManager(repo)
+	_, err := mgr.Update(context.Background(), userID, patch)
+
+	require.Error(t, err)
+	repo.AssertNotCalled(t, "Update")
+}
+
+// PM-08: Region without country — returns error before calling repo.
+func TestProfileManager_Update_RegionWithoutCountry_ReturnsErrorWithoutCallingRepo(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	patch := profile.ProfilePatch{Region: ptr("ES-MD")}
+
+	mgr := newTestManager(repo)
+	_, err := mgr.Update(context.Background(), userID, patch)
+
+	require.Error(t, err)
+	repo.AssertNotCalled(t, "Update")
+}
+
+// PM-09: Valid country, mismatched region — returns error before calling repo.
+func TestProfileManager_Update_MismatchedRegion_ReturnsErrorWithoutCallingRepo(t *testing.T) {
+	repo := &mockProfileRepository{}
+	userID := uuid.New()
+	patch := profile.ProfilePatch{Country: ptr("ES"), Region: ptr("FR-75")}
+
+	mgr := newTestManager(repo)
+	_, err := mgr.Update(context.Background(), userID, patch)
+
+	require.Error(t, err)
+	repo.AssertNotCalled(t, "Update")
+}
+
+// ---- List ----
+
+// PM-10: Delegates params to repository.
+func TestProfileManager_List_DelegatesToRepo_ReturnsItems(t *testing.T) {
+	repo := &mockProfileRepository{}
+	params := profile.ListParams{Page: 1, PageSize: 20}
+	items := []*profile.ProfileListItem{
+		{ID: func() *uuid.UUID { id := uuid.New(); return &id }(), DisplayName: ptr("Alice")},
+		{ID: func() *uuid.UUID { id := uuid.New(); return &id }(), DisplayName: ptr("Bob")},
+	}
+	repo.On("List", mock.Anything, params).Return(items, int64(2), nil)
+
+	mgr := newTestManager(repo)
+	got, total, err := mgr.List(context.Background(), params)
+
+	require.NoError(t, err)
+	assert.Equal(t, items, got)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+// PM-11: Propagates repository error.
+func TestProfileManager_List_RepoError_PropagatesError(t *testing.T) {
+	repo := &mockProfileRepository{}
+	params := profile.ListParams{Page: 1, PageSize: 20}
+	repoErr := errors.New("list db error")
+	repo.On("List", mock.Anything, params).Return(nil, int64(0), repoErr)
+
+	mgr := newTestManager(repo)
+	_, _, err := mgr.List(context.Background(), params)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repoErr)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

- Implements `ProfileManager` interface and `profileManager` struct in `api/internal/application/profile/manager.go`
- Provides four methods: `EnsureExists`, `GetByUserID`, `Update`, `List`
- `Update` validates location codes via `profile.ValidateLocation` before calling the repository; returns a validation error early if country/region are invalid
- Unit tests in `manager_test.go` cover all 11 cases (PM-01 through PM-11) using a `testify/mock` for `ProfileRepository`; coverage 94.7% (≥ 80% minimum)

## Test plan

- [x] `make test` passes (all unit tests green, no DB/network required)
- [x] Coverage for `internal/application/profile` is 94.7% (minimum ≥ 80%)
- [x] PM-01: EnsureExists delegates to repo successfully
- [x] PM-02: EnsureExists propagates repo error
- [x] PM-03: GetByUserID returns profile
- [x] PM-04: GetByUserID propagates ErrProfileNotFound
- [x] PM-05: Update with no location fields skips validation and calls repo
- [x] PM-06: Update with valid country + region calls repo
- [x] PM-07: Update with invalid country returns error without calling repo
- [x] PM-08: Update with region but no country returns error without calling repo
- [x] PM-09: Update with mismatched region returns error without calling repo
- [x] PM-10: List delegates params to repo and returns items
- [x] PM-11: List propagates repo error

Closes #99
Spec: docs/specs/FEATURE_user_profile/

🤖 Generated with [Claude Code](https://claude.com/claude-code)