### PR TITLE
[CK-93] T-05 — auth integration: profile initialisation on login

### DIFF
--- a/api/cmd/server/server.go
+++ b/api/cmd/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/courtknights/courtknights/internal/api/pats"
 	"github.com/courtknights/courtknights/internal/api/users"
 	appauth "github.com/courtknights/courtknights/internal/application/auth"
+	appprofile "github.com/courtknights/courtknights/internal/application/profile"
 	domainuser "github.com/courtknights/courtknights/internal/domain/user"
 	"github.com/courtknights/courtknights/internal/infrastructure/jwt"
 	"github.com/courtknights/courtknights/internal/infrastructure/oauth2"
@@ -32,6 +33,7 @@ func runServer(ctx context.Context, cfg Config) error {
 	// ---- repositories ----
 	userRepo := postgres.NewUserRepository(db)
 	patRepo := postgres.NewPATRepository(db)
+	profileRepo := postgres.NewProfileRepository(db)
 
 	// ---- jwt adapter ----
 	jwtAdapter, err := jwt.NewWithConfig(cfg.JWT.Secret, cfg.JWT.Expiry)
@@ -46,7 +48,8 @@ func runServer(ctx context.Context, cfg Config) error {
 	userManager := appauth.NewUserManager(userRepo, patRepo)
 	jwtManager := appauth.NewJWTManager(jwtAdapter)
 	oauthManager := appauth.NewOAuthManager(providers)
-	authManager := appauth.NewAuthManager(userManager, jwtManager, oauthManager)
+	profileManager := appprofile.NewProfileManager(profileRepo)
+	authManager := appauth.NewAuthManager(userManager, jwtManager, oauthManager, profileManager)
 
 	// ---- bootstrap admin ----
 	if err := runBootstrap(ctx, cfg.Bootstrap, authManager); err != nil {

--- a/api/internal/application/auth/bootstrap_integration_test.go
+++ b/api/internal/application/auth/bootstrap_integration_test.go
@@ -108,7 +108,7 @@ func TestBootstrapAdmin_EmptyDB_CreatesAdminAndPAT(t *testing.T) {
 	truncateTables(t)
 	mgr := newUserManagerForIntegration()
 
-	rawPAT, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "bootstrap-secret")
+	_, rawPAT, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "bootstrap-secret")
 	require.NoError(t, err)
 	assert.Equal(t, "bootstrap-secret", rawPAT, "raw PAT must be returned on first bootstrap")
 
@@ -130,11 +130,11 @@ func TestBootstrapAdmin_NonEmptyDB_IsNoOp(t *testing.T) {
 	mgr := newUserManagerForIntegration()
 
 	// First bootstrap creates the admin
-	_, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "secret-1")
+	_, _, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "secret-1")
 	require.NoError(t, err)
 
 	// Second bootstrap must be a no-op
-	result, err := mgr.BootstrapAdmin(context.Background(), "other@example.com", "Other", "secret-2")
+	_, result, err := mgr.BootstrapAdmin(context.Background(), "other@example.com", "Other", "secret-2")
 	require.NoError(t, err)
 	assert.Empty(t, result, "second bootstrap must return empty string")
 

--- a/api/internal/application/auth/manager.go
+++ b/api/internal/application/auth/manager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
+	appprofile "github.com/courtknights/courtknights/internal/application/profile"
 	"github.com/courtknights/courtknights/internal/domain/pat"
 	"github.com/courtknights/courtknights/internal/domain/user"
 	oauth2infra "github.com/courtknights/courtknights/internal/infrastructure/oauth2"
@@ -44,14 +45,16 @@ type AuthManager interface {
 }
 
 type authManager struct {
-	user  UserManager
-	jwt   JWTManager
-	oauth OAuthManager
+	user     UserManager
+	jwt      JWTManager
+	oauth    OAuthManager
+	profiles appprofile.ProfileManager
 }
 
-// NewAuthManager returns an AuthManager composed of the three sub-managers.
-func NewAuthManager(u UserManager, j JWTManager, o OAuthManager) AuthManager {
-	return &authManager{user: u, jwt: j, oauth: o}
+// NewAuthManager returns an AuthManager composed of the three sub-managers and a ProfileManager.
+// The ProfileManager is called on every successful login to ensure a profile exists for the user.
+func NewAuthManager(u UserManager, j JWTManager, o OAuthManager, profiles appprofile.ProfileManager) AuthManager {
+	return &authManager{user: u, jwt: j, oauth: o, profiles: profiles}
 }
 
 func (m *authManager) OAuthRedirectURL(provider user.Provider, state string) (string, error) {
@@ -65,6 +68,9 @@ func (m *authManager) OAuthCallback(ctx context.Context, provider user.Provider,
 	}
 	u, err := m.user.ResolveByOAuth(ctx, provider, info.ProviderID, info.Email, info.Name)
 	if err != nil {
+		return "", fmt.Errorf("auth manager: OAuthCallback: %w", err)
+	}
+	if err := m.profiles.EnsureExists(ctx, u.ID, u.Name); err != nil {
 		return "", fmt.Errorf("auth manager: OAuthCallback: %w", err)
 	}
 	return m.jwt.Sign(u)
@@ -81,6 +87,9 @@ func (m *authManager) DevicePoll(ctx context.Context, provider user.Provider, de
 	}
 	u, err := m.user.ResolveByOAuth(ctx, provider, info.ProviderID, info.Email, info.Name)
 	if err != nil {
+		return "", fmt.Errorf("auth manager: DevicePoll: %w", err)
+	}
+	if err := m.profiles.EnsureExists(ctx, u.ID, u.Name); err != nil {
 		return "", fmt.Errorf("auth manager: DevicePoll: %w", err)
 	}
 	return m.jwt.Sign(u)
@@ -123,5 +132,16 @@ func (m *authManager) UpdateUserRole(ctx context.Context, userID uuid.UUID, role
 }
 
 func (m *authManager) BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error) {
-	return m.user.BootstrapAdmin(ctx, email, name, rawPAT)
+	u, token, err := m.user.BootstrapAdmin(ctx, email, name, rawPAT)
+	if err != nil {
+		return "", fmt.Errorf("auth manager: BootstrapAdmin: %w", err)
+	}
+	if u == nil {
+		// No-op: users already exist.
+		return token, nil
+	}
+	if err := m.profiles.EnsureExists(ctx, u.ID, u.Name); err != nil {
+		return "", fmt.Errorf("auth manager: BootstrapAdmin: %w", err)
+	}
+	return token, nil
 }

--- a/api/internal/application/auth/manager_test.go
+++ b/api/internal/application/auth/manager_test.go
@@ -70,11 +70,13 @@ func newTestAuthManager(
 	patRepo *mockPATRepository,
 	providers map[user.Provider]oauth2infra.Provider,
 	jwtAdapt *mockJWTAdapter,
+	profileMgr *mockProfileManager,
 ) AuthManager {
 	return NewAuthManager(
 		NewUserManager(userRepo, patRepo),
 		NewJWTManager(jwtAdapt),
 		NewOAuthManager(providers),
+		profileMgr,
 	)
 }
 
@@ -88,6 +90,7 @@ func TestAuthManager_OAuthRedirectURL_ReturnsURL(t *testing.T) {
 		&mockUserRepository{}, &mockPATRepository{},
 		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov},
 		&mockJWTAdapter{},
+		&mockProfileManager{},
 	)
 
 	url, err := mgr.OAuthRedirectURL(user.ProviderGoogle, "state-123")
@@ -100,6 +103,7 @@ func TestAuthManager_OAuthRedirectURL_ErrWhenProviderNotConfigured(t *testing.T)
 		&mockUserRepository{}, &mockPATRepository{},
 		map[user.Provider]oauth2infra.Provider{},
 		&mockJWTAdapter{},
+		&mockProfileManager{},
 	)
 	_, err := mgr.OAuthRedirectURL(user.ProviderGoogle, "state")
 	require.Error(t, err)
@@ -113,19 +117,22 @@ func TestAuthManager_OAuthCallback_ValidCode_ReturnsJWT(t *testing.T) {
 	patRepo := &mockPATRepository{}
 	prov := &mockOAuth2Provider{}
 	jwtAdapt := &mockJWTAdapter{}
+	profileMgr := &mockProfileManager{}
 
-	resolved := &user.User{ID: uuid.New(), Email: "alice@example.com", Role: user.RoleUser}
+	resolved := &user.User{ID: uuid.New(), Name: "Alice", Email: "alice@example.com", Role: user.RoleUser}
 	prov.On("Exchange", mock.Anything, "valid-code").
 		Return(&oauth2infra.UserInfo{ProviderID: "g-1", Email: "alice@example.com", Name: "Alice"}, nil)
 	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).Return(resolved, nil)
+	profileMgr.On("EnsureExists", mock.Anything, resolved.ID, resolved.Name).Return(nil)
 	jwtAdapt.On("Sign", resolved).Return("signed-jwt", nil)
 
 	mgr := newTestAuthManager(userRepo, patRepo,
-		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov}, jwtAdapt)
+		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov}, jwtAdapt, profileMgr)
 
 	token, err := mgr.OAuthCallback(context.Background(), user.ProviderGoogle, "valid-code")
 	require.NoError(t, err)
 	assert.Equal(t, "signed-jwt", token)
+	profileMgr.AssertExpectations(t)
 }
 
 func TestAuthManager_OAuthCallback_InvalidCode_ReturnsError(t *testing.T) {
@@ -133,7 +140,7 @@ func TestAuthManager_OAuthCallback_InvalidCode_ReturnsError(t *testing.T) {
 	prov.On("Exchange", mock.Anything, "bad-code").Return(nil, errors.New("invalid_grant"))
 
 	mgr := newTestAuthManager(&mockUserRepository{}, &mockPATRepository{},
-		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov}, &mockJWTAdapter{})
+		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov}, &mockJWTAdapter{}, &mockProfileManager{})
 
 	_, err := mgr.OAuthCallback(context.Background(), user.ProviderGoogle, "bad-code")
 	require.Error(t, err)
@@ -149,7 +156,7 @@ func TestAuthManager_DeviceInit_ReturnsDeviceAuthResponse(t *testing.T) {
 	prov.On("DeviceAuth", mock.Anything).Return(expected, nil)
 
 	mgr := newTestAuthManager(&mockUserRepository{}, &mockPATRepository{},
-		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov}, &mockJWTAdapter{})
+		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov}, &mockJWTAdapter{}, &mockProfileManager{})
 
 	resp, err := mgr.DeviceInit(context.Background(), user.ProviderGitHub)
 	require.NoError(t, err)
@@ -164,7 +171,7 @@ func TestAuthManager_DevicePoll_Pending_ReturnsErrAuthorizationPending(t *testin
 		Return(nil, fmt.Errorf("poll: %w", oauth2infra.ErrAuthorizationPending))
 
 	mgr := newTestAuthManager(&mockUserRepository{}, &mockPATRepository{},
-		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov}, &mockJWTAdapter{})
+		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov}, &mockJWTAdapter{}, &mockProfileManager{})
 
 	_, err := mgr.DevicePoll(context.Background(), user.ProviderGitHub, "dev-code")
 	require.Error(t, err)
@@ -176,19 +183,22 @@ func TestAuthManager_DevicePoll_Authorised_ReturnsJWT(t *testing.T) {
 	patRepo := &mockPATRepository{}
 	prov := &mockOAuth2Provider{}
 	jwtAdapt := &mockJWTAdapter{}
+	profileMgr := &mockProfileManager{}
 
-	resolved := &user.User{ID: uuid.New(), Email: "bob@example.com", Role: user.RoleUser}
+	resolved := &user.User{ID: uuid.New(), Name: "Bob", Email: "bob@example.com", Role: user.RoleUser}
 	prov.On("DevicePoll", mock.Anything, "dev-code").
 		Return(&oauth2infra.UserInfo{ProviderID: "gh-42", Email: "bob@example.com", Name: "Bob"}, nil)
 	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).Return(resolved, nil)
+	profileMgr.On("EnsureExists", mock.Anything, resolved.ID, resolved.Name).Return(nil)
 	jwtAdapt.On("Sign", resolved).Return("device-jwt", nil)
 
 	mgr := newTestAuthManager(userRepo, patRepo,
-		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov}, jwtAdapt)
+		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov}, jwtAdapt, profileMgr)
 
 	token, err := mgr.DevicePoll(context.Background(), user.ProviderGitHub, "dev-code")
 	require.NoError(t, err)
 	assert.Equal(t, "device-jwt", token)
+	profileMgr.AssertExpectations(t)
 }
 
 // ---- ExchangePAT ----
@@ -208,7 +218,7 @@ func TestAuthManager_ExchangePAT_ValidPAT_ReturnsJWT(t *testing.T) {
 	userRepo.On("FindByProvider", mock.Anything, user.ProviderPAT, patID.String()).Return(linked, nil)
 	jwtAdapt.On("Sign", linked).Return("pat-jwt", nil)
 
-	mgr := newTestAuthManager(userRepo, patRepo, map[user.Provider]oauth2infra.Provider{}, jwtAdapt)
+	mgr := newTestAuthManager(userRepo, patRepo, map[user.Provider]oauth2infra.Provider{}, jwtAdapt, &mockProfileManager{})
 
 	token, err := mgr.ExchangePAT(context.Background(), rawKey)
 	require.NoError(t, err)
@@ -219,7 +229,7 @@ func TestAuthManager_ExchangePAT_InvalidPAT_ReturnsErrInvalidPAT(t *testing.T) {
 	patRepo := &mockPATRepository{}
 	patRepo.On("FindAll", mock.Anything).Return([]*pat.PAT{}, nil)
 
-	mgr := newTestAuthManager(&mockUserRepository{}, patRepo, map[user.Provider]oauth2infra.Provider{}, &mockJWTAdapter{})
+	mgr := newTestAuthManager(&mockUserRepository{}, patRepo, map[user.Provider]oauth2infra.Provider{}, &mockJWTAdapter{}, &mockProfileManager{})
 
 	_, err := mgr.ExchangePAT(context.Background(), "wrong-key")
 	require.Error(t, err)
@@ -239,7 +249,7 @@ func TestAuthManager_RefreshJWT_ValidToken_ReturnsNewJWT(t *testing.T) {
 	jwtAdapt.On("Validate", "old-token").Return(claims, nil)
 	jwtAdapt.On("Sign", mock.AnythingOfType("*user.User")).Return("new-jwt", nil)
 
-	mgr := newTestAuthManager(&mockUserRepository{}, &mockPATRepository{}, map[user.Provider]oauth2infra.Provider{}, jwtAdapt)
+	mgr := newTestAuthManager(&mockUserRepository{}, &mockPATRepository{}, map[user.Provider]oauth2infra.Provider{}, jwtAdapt, &mockProfileManager{})
 
 	token, err := mgr.RefreshJWT(context.Background(), "old-token")
 	require.NoError(t, err)
@@ -250,9 +260,174 @@ func TestAuthManager_RefreshJWT_ExpiredToken_ReturnsErrUnauthorized(t *testing.T
 	jwtAdapt := &mockJWTAdapter{}
 	jwtAdapt.On("Validate", "expired-token").Return(nil, fmt.Errorf("%w", ckerrors.ErrUnauthorized))
 
-	mgr := newTestAuthManager(&mockUserRepository{}, &mockPATRepository{}, map[user.Provider]oauth2infra.Provider{}, jwtAdapt)
+	mgr := newTestAuthManager(&mockUserRepository{}, &mockPATRepository{}, map[user.Provider]oauth2infra.Provider{}, jwtAdapt, &mockProfileManager{})
 
 	_, err := mgr.RefreshJWT(context.Background(), "expired-token")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ckerrors.ErrUnauthorized)
+}
+
+// ---- Auth Integration: profile initialisation on login (AI-01 through AI-07) ----
+
+// AI-01: OAuthCallback calls EnsureExists after user upsert; JWT is issued.
+func TestAuthManager_AI01_OAuthCallback_CallsEnsureExists(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	prov := &mockOAuth2Provider{}
+	jwtAdapt := &mockJWTAdapter{}
+	profileMgr := &mockProfileManager{}
+
+	userID := uuid.New()
+	resolved := &user.User{ID: userID, Name: "Alice", Email: "alice@example.com", Role: user.RoleUser}
+	prov.On("Exchange", mock.Anything, "code-ai01").
+		Return(&oauth2infra.UserInfo{ProviderID: "g-1", Email: "alice@example.com", Name: "Alice"}, nil)
+	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).Return(resolved, nil)
+	profileMgr.On("EnsureExists", mock.Anything, userID, "Alice").Return(nil)
+	jwtAdapt.On("Sign", resolved).Return("jwt-ai01", nil)
+
+	mgr := newTestAuthManager(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov}, jwtAdapt, profileMgr)
+
+	token, err := mgr.OAuthCallback(context.Background(), user.ProviderGoogle, "code-ai01")
+	require.NoError(t, err)
+	assert.Equal(t, "jwt-ai01", token)
+	profileMgr.AssertCalled(t, "EnsureExists", mock.Anything, userID, "Alice")
+}
+
+// AI-02: OAuthCallback propagates EnsureExists error; JWT not issued.
+func TestAuthManager_AI02_OAuthCallback_PropagatesEnsureExistsError(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	prov := &mockOAuth2Provider{}
+	jwtAdapt := &mockJWTAdapter{}
+	profileMgr := &mockProfileManager{}
+
+	ensureErr := errors.New("profile store failure")
+	resolved := &user.User{ID: uuid.New(), Name: "Alice", Email: "alice@example.com", Role: user.RoleUser}
+	prov.On("Exchange", mock.Anything, "code-ai02").
+		Return(&oauth2infra.UserInfo{ProviderID: "g-2", Email: "alice@example.com", Name: "Alice"}, nil)
+	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).Return(resolved, nil)
+	profileMgr.On("EnsureExists", mock.Anything, resolved.ID, resolved.Name).Return(ensureErr)
+
+	mgr := newTestAuthManager(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{user.ProviderGoogle: prov}, jwtAdapt, profileMgr)
+
+	_, err := mgr.OAuthCallback(context.Background(), user.ProviderGoogle, "code-ai02")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ensureErr)
+	jwtAdapt.AssertNotCalled(t, "Sign")
+}
+
+// AI-03: DevicePoll calls EnsureExists after user resolution; JWT is issued.
+func TestAuthManager_AI03_DevicePoll_CallsEnsureExists(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	prov := &mockOAuth2Provider{}
+	jwtAdapt := &mockJWTAdapter{}
+	profileMgr := &mockProfileManager{}
+
+	userID := uuid.New()
+	resolved := &user.User{ID: userID, Name: "Bob", Email: "bob@example.com", Role: user.RoleUser}
+	prov.On("DevicePoll", mock.Anything, "device-ai03").
+		Return(&oauth2infra.UserInfo{ProviderID: "gh-3", Email: "bob@example.com", Name: "Bob"}, nil)
+	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).Return(resolved, nil)
+	profileMgr.On("EnsureExists", mock.Anything, userID, "Bob").Return(nil)
+	jwtAdapt.On("Sign", resolved).Return("jwt-ai03", nil)
+
+	mgr := newTestAuthManager(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov}, jwtAdapt, profileMgr)
+
+	token, err := mgr.DevicePoll(context.Background(), user.ProviderGitHub, "device-ai03")
+	require.NoError(t, err)
+	assert.Equal(t, "jwt-ai03", token)
+	profileMgr.AssertCalled(t, "EnsureExists", mock.Anything, userID, "Bob")
+}
+
+// AI-04: DevicePoll propagates EnsureExists error.
+func TestAuthManager_AI04_DevicePoll_PropagatesEnsureExistsError(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	prov := &mockOAuth2Provider{}
+	jwtAdapt := &mockJWTAdapter{}
+	profileMgr := &mockProfileManager{}
+
+	ensureErr := errors.New("db unavailable")
+	resolved := &user.User{ID: uuid.New(), Name: "Bob", Email: "bob@example.com", Role: user.RoleUser}
+	prov.On("DevicePoll", mock.Anything, "device-ai04").
+		Return(&oauth2infra.UserInfo{ProviderID: "gh-4", Email: "bob@example.com", Name: "Bob"}, nil)
+	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).Return(resolved, nil)
+	profileMgr.On("EnsureExists", mock.Anything, resolved.ID, resolved.Name).Return(ensureErr)
+
+	mgr := newTestAuthManager(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{user.ProviderGitHub: prov}, jwtAdapt, profileMgr)
+
+	_, err := mgr.DevicePoll(context.Background(), user.ProviderGitHub, "device-ai04")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ensureErr)
+	jwtAdapt.AssertNotCalled(t, "Sign")
+}
+
+// AI-05: BootstrapAdmin calls EnsureExists after admin user is created.
+func TestAuthManager_AI05_BootstrapAdmin_CallsEnsureExists(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	profileMgr := &mockProfileManager{}
+
+	adminID := uuid.New()
+	savedPATID := uuid.New()
+	userRepo.On("CountAll", mock.Anything).Return(int64(0), nil)
+	patRepo.On("Save", mock.Anything, mock.AnythingOfType("*pat.PAT")).
+		Return(&pat.PAT{ID: savedPATID}, nil)
+	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).
+		Return(&user.User{ID: adminID, Name: "Admin"}, nil)
+	profileMgr.On("EnsureExists", mock.Anything, adminID, "Admin").Return(nil)
+
+	mgr := newTestAuthManager(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{}, &mockJWTAdapter{}, profileMgr)
+
+	token, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "secret-ai05")
+	require.NoError(t, err)
+	assert.Equal(t, "secret-ai05", token)
+	profileMgr.AssertCalled(t, "EnsureExists", mock.Anything, adminID, "Admin")
+}
+
+// AI-06: BootstrapAdmin propagates EnsureExists error.
+func TestAuthManager_AI06_BootstrapAdmin_PropagatesEnsureExistsError(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	profileMgr := &mockProfileManager{}
+
+	ensureErr := errors.New("profile init failed")
+	savedPATID := uuid.New()
+	adminID := uuid.New()
+	userRepo.On("CountAll", mock.Anything).Return(int64(0), nil)
+	patRepo.On("Save", mock.Anything, mock.AnythingOfType("*pat.PAT")).
+		Return(&pat.PAT{ID: savedPATID}, nil)
+	userRepo.On("Upsert", mock.Anything, mock.AnythingOfType("*user.User")).
+		Return(&user.User{ID: adminID, Name: "Admin"}, nil)
+	profileMgr.On("EnsureExists", mock.Anything, adminID, "Admin").Return(ensureErr)
+
+	mgr := newTestAuthManager(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{}, &mockJWTAdapter{}, profileMgr)
+
+	_, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "secret-ai06")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ensureErr)
+}
+
+// AI-07: BootstrapAdmin no-op (users already exist) — EnsureExists NOT called.
+func TestAuthManager_AI07_BootstrapAdmin_NoOp_EnsureExistsNotCalled(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	patRepo := &mockPATRepository{}
+	profileMgr := &mockProfileManager{}
+
+	userRepo.On("CountAll", mock.Anything).Return(int64(1), nil)
+
+	mgr := newTestAuthManager(userRepo, patRepo,
+		map[user.Provider]oauth2infra.Provider{}, &mockJWTAdapter{}, profileMgr)
+
+	token, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "secret-ai07")
+	require.NoError(t, err)
+	assert.Empty(t, token)
+	profileMgr.AssertNotCalled(t, "EnsureExists")
 }

--- a/api/internal/application/auth/mocks_test.go
+++ b/api/internal/application/auth/mocks_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/courtknights/courtknights/internal/domain/pat"
+	domainprofile "github.com/courtknights/courtknights/internal/domain/profile"
 	"github.com/courtknights/courtknights/internal/domain/user"
 )
 
@@ -75,4 +76,35 @@ func (m *mockPATRepository) Save(ctx context.Context, p *pat.PAT) (*pat.PAT, err
 
 func (m *mockPATRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return m.Called(ctx, id).Error(0)
+}
+
+// mockProfileManager is a testify mock for appprofile.ProfileManager.
+type mockProfileManager struct{ mock.Mock }
+
+func (m *mockProfileManager) EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error {
+	return m.Called(ctx, userID, displayName).Error(0)
+}
+
+func (m *mockProfileManager) GetByUserID(ctx context.Context, userID uuid.UUID) (*domainprofile.Profile, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domainprofile.Profile), args.Error(1)
+}
+
+func (m *mockProfileManager) Update(ctx context.Context, userID uuid.UUID, patch domainprofile.ProfilePatch) (*domainprofile.Profile, error) {
+	args := m.Called(ctx, userID, patch)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domainprofile.Profile), args.Error(1)
+}
+
+func (m *mockProfileManager) List(ctx context.Context, params domainprofile.ListParams) ([]*domainprofile.ProfileListItem, int64, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(int64), args.Error(2)
+	}
+	return args.Get(0).([]*domainprofile.ProfileListItem), args.Get(1).(int64), args.Error(2)
 }

--- a/api/internal/application/auth/user_manager.go
+++ b/api/internal/application/auth/user_manager.go
@@ -21,7 +21,7 @@ type UserManager interface {
 	CreatePAT(ctx context.Context, userID uuid.UUID, expiresAt *time.Time) (string, error)
 	RevokePAT(ctx context.Context, id uuid.UUID) error
 	ListPATs(ctx context.Context) ([]*pat.PAT, error)
-	BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error)
+	BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (*user.User, string, error)
 	UpdateUserRole(ctx context.Context, userID uuid.UUID, role user.Role) error
 }
 
@@ -134,18 +134,18 @@ func (m *userManager) UpdateUserRole(ctx context.Context, userID uuid.UUID, role
 	return nil
 }
 
-func (m *userManager) BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (string, error) {
+func (m *userManager) BootstrapAdmin(ctx context.Context, email, name, rawPAT string) (*user.User, string, error) {
 	count, err := m.users.CountAll(ctx)
 	if err != nil {
-		return "", fmt.Errorf("user manager: BootstrapAdmin: count users: %w", err)
+		return nil, "", fmt.Errorf("user manager: BootstrapAdmin: count users: %w", err)
 	}
 	if count > 0 {
-		return "", nil
+		return nil, "", nil
 	}
 
 	salt, err := generateSalt()
 	if err != nil {
-		return "", fmt.Errorf("user manager: BootstrapAdmin: generate salt: %w", err)
+		return nil, "", fmt.Errorf("user manager: BootstrapAdmin: generate salt: %w", err)
 	}
 
 	savedPAT, err := m.pats.Save(ctx, &pat.PAT{
@@ -153,18 +153,19 @@ func (m *userManager) BootstrapAdmin(ctx context.Context, email, name, rawPAT st
 		Salt:    salt,
 	})
 	if err != nil {
-		return "", fmt.Errorf("user manager: BootstrapAdmin: save PAT: %w", err)
+		return nil, "", fmt.Errorf("user manager: BootstrapAdmin: save PAT: %w", err)
 	}
 
-	if _, err := m.users.Upsert(ctx, &user.User{
+	u, err := m.users.Upsert(ctx, &user.User{
 		Email:      email,
 		Name:       name,
 		Role:       user.RoleAdmin,
 		Provider:   user.ProviderPAT,
 		ProviderID: savedPAT.ID.String(),
-	}); err != nil {
-		return "", fmt.Errorf("user manager: BootstrapAdmin: upsert user: %w", err)
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("user manager: BootstrapAdmin: upsert user: %w", err)
 	}
 
-	return rawPAT, nil
+	return u, rawPAT, nil
 }

--- a/api/internal/application/auth/user_manager_test.go
+++ b/api/internal/application/auth/user_manager_test.go
@@ -172,9 +172,10 @@ func TestManager_BootstrapAdmin_CreatesAdminAndPAT(t *testing.T) {
 	users.On("Upsert", context.Background(), mock.AnythingOfType("*user.User")).
 		Return(&user.User{ID: uuid.New(), Role: user.RoleAdmin}, nil)
 
-	rawPAT, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "bootstrap-secret")
+	u, rawPAT, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "bootstrap-secret")
 	require.NoError(t, err)
 	assert.Equal(t, "bootstrap-secret", rawPAT)
+	assert.NotNil(t, u)
 	users.AssertExpectations(t)
 	pats.AssertExpectations(t)
 }
@@ -186,8 +187,9 @@ func TestManager_BootstrapAdmin_IsNoOpWhenUsersExist(t *testing.T) {
 
 	users.On("CountAll", context.Background()).Return(int64(1), nil)
 
-	rawPAT, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "bootstrap-secret")
+	u, rawPAT, err := mgr.BootstrapAdmin(context.Background(), "admin@example.com", "Admin", "bootstrap-secret")
 	require.NoError(t, err)
+	assert.Nil(t, u)
 	assert.Empty(t, rawPAT)
 	// Save and Upsert must NOT be called
 	pats.AssertNotCalled(t, "Save")

--- a/api/internal/application/profile/manager.go
+++ b/api/internal/application/profile/manager.go
@@ -43,6 +43,11 @@ func NewProfileManager(repo profile.ProfileRepository) ProfileManager {
 	return &profileManager{profiles: repo}
 }
 
+// EnsureExists is called by AuthManager on every successful login (OAuthCallback,
+// DevicePoll, BootstrapAdmin) after the user row is resolved or created. It
+// delegates to the repository which issues an INSERT ... ON CONFLICT DO NOTHING,
+// so on the first login a profile row is created and on subsequent logins the
+// call is a no-op.
 func (m *profileManager) EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error {
 	if err := m.profiles.EnsureExists(ctx, userID, displayName); err != nil {
 		return fmt.Errorf("profile manager: EnsureExists: %w", err)

--- a/docs/testing/regression_map.md
+++ b/docs/testing/regression_map.md
@@ -3,7 +3,7 @@
 Tracks dependencies between features. Update this file every time a feature is merged.
 When a feature is modified, all dependent features in this map must have their tests re-run.
 
-- **Last updated:** 2026-04-03
+- **Last updated:** 2026-04-04
 
 ---
 
@@ -39,3 +39,5 @@ When a feature is modified, all dependent features in this map must have their t
 | FEATURE_user_profile / T-01 | `profile` domain entities (`Profile`, `Preferences`, enums), `ProfileRepository` interface, `ValidateLocation`, `ckerrors.ErrProfileNotFound` | — | FEATURE_user_profile / T-03..T-07 |
 | FEATURE_user_profile / T-02 | `user_profiles` DB migration (003) + schema definition | FEATURE_authentication / postgres | FEATURE_user_profile / T-03 |
 | FEATURE_user_profile / T-03 | `ProfileRepository` PostgreSQL implementation (`EnsureExists`, `FindByUserID`, `Update`, `List`) | FEATURE_user_profile / T-01, T-02, FEATURE_authentication / postgres | FEATURE_user_profile / T-05 |
+| FEATURE_user_profile / T-04 | `ProfileManager` application layer (`EnsureExists`, `GetByUserID`, `Update`, `List`) | FEATURE_user_profile / T-01, T-03 | FEATURE_user_profile / T-05, T-06, T-07 |
+| FEATURE_user_profile / T-05 | Auth integration: profile initialisation on login (`AuthManager` extended, `UserManager.BootstrapAdmin` returns user, server wiring) | FEATURE_user_profile / T-03, T-04, FEATURE_authentication / application | FEATURE_authentication / cmd/server |


### PR DESCRIPTION
## Summary

- Extend `AuthManager` with a `ProfileManager` field; call `EnsureExists` in `OAuthCallback`, `DevicePoll`, and `BootstrapAdmin` after the user is resolved or created
- Refactor `UserManager.BootstrapAdmin` to return `(*user.User, string, error)` so `AuthManager` can obtain the new admin's UUID without a second `ResolveByPAT` lookup
- Wire `profileRepo` and `profileManager` in `cmd/server/server.go`; inject into `NewAuthManager`
- Add unit tests AI-01..AI-07 covering `EnsureExists` call, error propagation, and no-op path for each login surface
- Update `regression_map.md` with T-04 (missed in previous PR) and T-05 entries

## Test plan

- [x] `make test` passes — all 14 packages, no failures
- [x] AI-01: `OAuthCallback` calls `EnsureExists` after user upsert; JWT issued
- [x] AI-02: `OAuthCallback` propagates `EnsureExists` error; JWT not issued
- [x] AI-03: `DevicePoll` calls `EnsureExists` after user resolution; JWT issued
- [x] AI-04: `DevicePoll` propagates `EnsureExists` error
- [x] AI-05: `BootstrapAdmin` calls `EnsureExists` after admin created
- [x] AI-06: `BootstrapAdmin` propagates `EnsureExists` error
- [x] AI-07: `BootstrapAdmin` no-op (users exist) — `EnsureExists` not called

Closes #100
Spec: docs/specs/FEATURE_user_profile/

🤖 Generated with [Claude Code](https://claude.com/claude-code)