### PR TITLE
[CK-93] T-06 — API: own-profile and get-by-ID endpoints

### DIFF
--- a/api/cmd/server/server.go
+++ b/api/cmd/server/server.go
@@ -60,7 +60,7 @@ func runServer(ctx context.Context, cfg Config) error {
 	router := api.New()
 	router.MountPublic("/auth", apiauth.NewRoutes(apiauth.NewHandler(authManager)))
 	router.MountProtected("/api/v1", common.JWTMiddleware(jwtManager), pats.NewRoutes(pats.NewHandler(authManager)))
-	router.MountProtected("/api/v1", common.JWTMiddleware(jwtManager), users.NewRoutes(users.NewHandler(authManager)))
+	router.MountProtected("/api/v1", common.JWTMiddleware(jwtManager), users.NewRoutes(users.NewHandler(authManager, profileManager)))
 
 	// ---- start server ----
 	addr := fmt.Sprintf(":%s", cfg.Server.Port)

--- a/api/internal/api/users/handler.go
+++ b/api/internal/api/users/handler.go
@@ -2,24 +2,31 @@
 package users
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
 	"github.com/courtknights/courtknights/internal/api/common"
 	appauth "github.com/courtknights/courtknights/internal/application/auth"
+	appprofile "github.com/courtknights/courtknights/internal/application/profile"
+	"github.com/courtknights/courtknights/internal/domain/ckerrors"
+	"github.com/courtknights/courtknights/internal/domain/profile"
 	"github.com/courtknights/courtknights/internal/domain/user"
 )
 
 // Handler handles all user management HTTP requests.
 type Handler struct {
-	manager appauth.AuthManager
+	manager  appauth.AuthManager
+	profiles appprofile.ProfileManager
 }
 
-// NewHandler returns a Handler backed by the given AuthManager.
-func NewHandler(manager appauth.AuthManager) *Handler {
-	return &Handler{manager: manager}
+// NewHandler returns a Handler backed by the given AuthManager and ProfileManager.
+func NewHandler(manager appauth.AuthManager, profiles appprofile.ProfileManager) *Handler {
+	return &Handler{manager: manager, profiles: profiles}
 }
 
 // me returns the authenticated user's profile from the JWT context.
@@ -61,4 +68,233 @@ func (h *Handler) updateRole(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"id": userID.String(), "role": string(role)})
+}
+
+// getMyProfile returns the authenticated user's profile.
+// GET /api/v1/users/me/profile
+func (h *Handler) getMyProfile(c echo.Context) error {
+	sub, ok := c.Get(common.ContextKeySub).(string)
+	if !ok || sub == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "missing sub claim")
+	}
+
+	userID, err := uuid.Parse(sub)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid sub claim")
+	}
+
+	p, err := h.profiles.GetByUserID(c.Request().Context(), userID)
+	if err != nil {
+		if errors.Is(err, ckerrors.ErrProfileNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get profile")
+	}
+
+	return c.JSON(http.StatusOK, toProfileResponse(p))
+}
+
+// updateMyProfile applies a partial update to the authenticated user's profile.
+// PUT /api/v1/users/me/profile
+func (h *Handler) updateMyProfile(c echo.Context) error {
+	sub, ok := c.Get(common.ContextKeySub).(string)
+	if !ok || sub == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "missing sub claim")
+	}
+
+	userID, err := uuid.Parse(sub)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid sub claim")
+	}
+
+	var req profilePatchRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid request body")
+	}
+
+	patch, err := req.toPatch()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	p, err := h.profiles.Update(c.Request().Context(), userID, patch)
+	if err != nil {
+		if errors.Is(err, ckerrors.ErrProfileNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "profile not found")
+		}
+		// Validation errors from the manager (invalid location codes, etc.) are 400.
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, toProfileResponse(p))
+}
+
+// getUserProfile returns the profile for a given user by UUID path param.
+// GET /api/v1/users/:id/profile
+func (h *Handler) getUserProfile(c echo.Context) error {
+	userID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid user id")
+	}
+
+	p, err := h.profiles.GetByUserID(c.Request().Context(), userID)
+	if err != nil {
+		if errors.Is(err, ckerrors.ErrProfileNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "profile not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get profile")
+	}
+
+	return c.JSON(http.StatusOK, toProfileResponse(p))
+}
+
+// profilePatchRequest is the JSON body for the update-profile endpoint.
+// All fields are optional (partial update).
+type profilePatchRequest struct {
+	DisplayName *string             `json:"display_name"`
+	City        *string             `json:"city"`
+	Region      *string             `json:"region"`
+	Country     *string             `json:"country"`
+	Gender      *string             `json:"gender"`
+	DateOfBirth *string             `json:"date_of_birth"`
+	Category    *string             `json:"category"`
+	Preferences *preferencesRequest `json:"preferences"`
+}
+
+// preferencesRequest is the JSON representation of profile Preferences in the request body.
+type preferencesRequest struct {
+	CourtSide  *string `json:"court_side"`
+	Handedness *string `json:"handedness"`
+}
+
+// toPatch converts the JSON request into a domain ProfilePatch.
+// Returns an error if any enum value is unrecognised.
+func (r *profilePatchRequest) toPatch() (profile.ProfilePatch, error) {
+	patch := profile.ProfilePatch{
+		DisplayName: r.DisplayName,
+		City:        r.City,
+		Region:      r.Region,
+		Country:     r.Country,
+	}
+
+	if r.Gender != nil {
+		g := profile.Gender(*r.Gender)
+		if g != profile.GenderMale && g != profile.GenderFemale {
+			return profile.ProfilePatch{}, fmt.Errorf("invalid gender value: %q", *r.Gender)
+		}
+		patch.Gender = &g
+	}
+
+	if r.DateOfBirth != nil {
+		t, err := time.Parse("2006-01-02", *r.DateOfBirth)
+		if err != nil {
+			return profile.ProfilePatch{}, fmt.Errorf("invalid date_of_birth: must be YYYY-MM-DD")
+		}
+		patch.DateOfBirth = &t
+	}
+
+	if r.Category != nil {
+		cat := profile.Category(*r.Category)
+		switch cat {
+		case profile.CategoryFirst, profile.CategorySecond, profile.CategoryThird,
+			profile.CategoryFourth, profile.CategoryFifth:
+		default:
+			return profile.ProfilePatch{}, fmt.Errorf("invalid category value: %q", *r.Category)
+		}
+		patch.Category = &cat
+	}
+
+	if r.Preferences != nil {
+		prefs, err := toPreferences(r.Preferences)
+		if err != nil {
+			return profile.ProfilePatch{}, err
+		}
+		patch.Preferences = &prefs
+	}
+
+	return patch, nil
+}
+
+// toPreferences converts a preferencesRequest into a domain Preferences value.
+func toPreferences(r *preferencesRequest) (profile.Preferences, error) {
+	var prefs profile.Preferences
+
+	if r.CourtSide != nil {
+		cs := profile.CourtSide(*r.CourtSide)
+		switch cs {
+		case profile.CourtSideDrive, profile.CourtSideBackhand, profile.CourtSideBoth:
+		default:
+			return profile.Preferences{}, fmt.Errorf("invalid court_side value: %q", *r.CourtSide)
+		}
+		prefs.CourtSide = &cs
+	}
+
+	if r.Handedness != nil {
+		h := profile.Handedness(*r.Handedness)
+		if h != profile.HandednessRight && h != profile.HandednessLeft {
+			return profile.Preferences{}, fmt.Errorf("invalid handedness value: %q", *r.Handedness)
+		}
+		prefs.Handedness = &h
+	}
+
+	return prefs, nil
+}
+
+// profileResponse is the JSON representation of a Profile returned by the API.
+type profileResponse struct {
+	UserID      string              `json:"user_id"`
+	DisplayName string              `json:"display_name"`
+	City        *string             `json:"city,omitempty"`
+	Region      *string             `json:"region,omitempty"`
+	Country     *string             `json:"country,omitempty"`
+	Gender      *string             `json:"gender,omitempty"`
+	DateOfBirth *string             `json:"date_of_birth,omitempty"`
+	Category    *string             `json:"category,omitempty"`
+	Preferences preferencesResponse `json:"preferences"`
+	UpdatedAt   string              `json:"updated_at"`
+}
+
+// preferencesResponse is the JSON representation of Preferences in API responses.
+type preferencesResponse struct {
+	CourtSide  *string `json:"court_side,omitempty"`
+	Handedness *string `json:"handedness,omitempty"`
+}
+
+// toProfileResponse converts a domain Profile to its API response representation.
+func toProfileResponse(p *profile.Profile) profileResponse {
+	resp := profileResponse{
+		UserID:      p.UserID.String(),
+		DisplayName: p.DisplayName,
+		City:        p.City,
+		Region:      p.Region,
+		Country:     p.Country,
+		UpdatedAt:   p.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+
+	if p.Gender != nil {
+		s := string(*p.Gender)
+		resp.Gender = &s
+	}
+
+	if p.DateOfBirth != nil {
+		s := p.DateOfBirth.UTC().Format("2006-01-02")
+		resp.DateOfBirth = &s
+	}
+
+	if p.Category != nil {
+		s := string(*p.Category)
+		resp.Category = &s
+	}
+
+	if p.Preferences.CourtSide != nil {
+		s := string(*p.Preferences.CourtSide)
+		resp.Preferences.CourtSide = &s
+	}
+
+	if p.Preferences.Handedness != nil {
+		s := string(*p.Preferences.Handedness)
+		resp.Preferences.Handedness = &s
+	}
+
+	return resp
 }

--- a/api/internal/api/users/handler_profile_test.go
+++ b/api/internal/api/users/handler_profile_test.go
@@ -1,0 +1,347 @@
+package users
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/courtknights/courtknights/internal/api/common"
+	appprofile "github.com/courtknights/courtknights/internal/application/profile"
+	"github.com/courtknights/courtknights/internal/domain/ckerrors"
+	"github.com/courtknights/courtknights/internal/domain/profile"
+)
+
+// ---- mock ProfileManager ----
+
+type mockProfileManager struct{ mock.Mock }
+
+func (m *mockProfileManager) EnsureExists(ctx context.Context, userID uuid.UUID, displayName string) error {
+	return m.Called(ctx, userID, displayName).Error(0)
+}
+
+func (m *mockProfileManager) GetByUserID(ctx context.Context, userID uuid.UUID) (*profile.Profile, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*profile.Profile), args.Error(1)
+}
+
+func (m *mockProfileManager) Update(ctx context.Context, userID uuid.UUID, patch profile.ProfilePatch) (*profile.Profile, error) {
+	args := m.Called(ctx, userID, patch)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*profile.Profile), args.Error(1)
+}
+
+func (m *mockProfileManager) List(ctx context.Context, params profile.ListParams) ([]*profile.ProfileListItem, int64, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Get(1).(int64), args.Error(2)
+	}
+	return args.Get(0).([]*profile.ProfileListItem), args.Get(1).(int64), args.Error(2)
+}
+
+// compile-time check
+var _ appprofile.ProfileManager = (*mockProfileManager)(nil)
+
+// ---- helpers ----
+
+func newProfileTestHandler(profiles appprofile.ProfileManager) (*Handler, *echo.Echo) {
+	return NewHandler(&mockAuthManager{}, profiles), echo.New()
+}
+
+func contextWithAuthAndSub(e *echo.Echo, method, target, body, sub string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(common.ContextKeySub, sub)
+	c.Set(common.ContextKeyEmail, "user@example.com")
+	c.Set(common.ContextKeyRole, "user")
+	return c, rec
+}
+
+func buildTestProfile(userID uuid.UUID) *profile.Profile {
+	city := "Madrid"
+	region := "ES-MD"
+	country := "ES"
+	gender := profile.GenderMale
+	dob := time.Date(1990, 5, 14, 0, 0, 0, 0, time.UTC)
+	category := profile.CategoryThird
+	cs := profile.CourtSideDrive
+	hand := profile.HandednessRight
+
+	return &profile.Profile{
+		UserID:      userID,
+		DisplayName: "Álvaro Agea",
+		City:        &city,
+		Region:      &region,
+		Country:     &country,
+		Gender:      &gender,
+		DateOfBirth: &dob,
+		Category:    &category,
+		Preferences: profile.Preferences{
+			CourtSide:  &cs,
+			Handedness: &hand,
+		},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+}
+
+// ---- GET /users/me/profile ----
+
+// HP-01: Returns own profile with 200.
+func TestGetMyProfile_ReturnsProfile(t *testing.T) {
+	userID := uuid.New()
+	p := buildTestProfile(userID)
+	mgr := &mockProfileManager{}
+	mgr.On("GetByUserID", mock.Anything, userID).Return(p, nil)
+
+	h, e := newProfileTestHandler(mgr)
+	c, rec := contextWithAuthAndSub(e, http.MethodGet, "/api/v1/users/me/profile", "", userID.String())
+
+	err := h.getMyProfile(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, userID.String())
+	assert.Contains(t, body, "Álvaro Agea")
+	assert.Contains(t, body, "Madrid")
+	mgr.AssertExpectations(t)
+}
+
+// HP-02: Profile not found returns 404.
+func TestGetMyProfile_ProfileNotFound_Returns404(t *testing.T) {
+	userID := uuid.New()
+	mgr := &mockProfileManager{}
+	mgr.On("GetByUserID", mock.Anything, userID).Return(nil, ckerrors.ErrProfileNotFound)
+
+	h, e := newProfileTestHandler(mgr)
+	c, _ := contextWithAuthAndSub(e, http.MethodGet, "/api/v1/users/me/profile", "", userID.String())
+
+	err := h.getMyProfile(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusNotFound, he.Code)
+	mgr.AssertExpectations(t)
+}
+
+// HP-03: Missing / invalid sub claim returns 400.
+func TestGetMyProfile_InvalidSub_Returns400(t *testing.T) {
+	mgr := &mockProfileManager{}
+	h, e := newProfileTestHandler(mgr)
+	c, _ := contextWithAuthAndSub(e, http.MethodGet, "/api/v1/users/me/profile", "", "not-a-uuid")
+
+	err := h.getMyProfile(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+// HP-03b: Sub claim absent returns 400.
+func TestGetMyProfile_MissingSub_Returns400(t *testing.T) {
+	mgr := &mockProfileManager{}
+	h, e := newProfileTestHandler(mgr)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/profile", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// sub not set in context
+
+	err := h.getMyProfile(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+// ---- PUT /users/me/profile ----
+
+// HP-04: Partial update — display_name only returns 200 with updated profile.
+func TestUpdateMyProfile_DisplayNameOnly_Returns200(t *testing.T) {
+	userID := uuid.New()
+	newName := "X"
+	p := buildTestProfile(userID)
+	p.DisplayName = newName
+
+	mgr := &mockProfileManager{}
+	mgr.On("Update", mock.Anything, userID, mock.MatchedBy(func(patch profile.ProfilePatch) bool {
+		return patch.DisplayName != nil && *patch.DisplayName == newName
+	})).Return(p, nil)
+
+	h, e := newProfileTestHandler(mgr)
+	c, rec := contextWithAuthAndSub(e, http.MethodPut, "/api/v1/users/me/profile",
+		`{"display_name":"X"}`, userID.String())
+
+	err := h.updateMyProfile(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), newName)
+	mgr.AssertExpectations(t)
+}
+
+// HP-05: Full update — all fields present returns 200.
+func TestUpdateMyProfile_AllFields_Returns200(t *testing.T) {
+	userID := uuid.New()
+	p := buildTestProfile(userID)
+	mgr := &mockProfileManager{}
+	mgr.On("Update", mock.Anything, userID, mock.Anything).Return(p, nil)
+
+	body := `{
+		"display_name": "Álvaro",
+		"city": "Madrid",
+		"region": "ES-MD",
+		"country": "ES",
+		"gender": "male",
+		"date_of_birth": "1990-05-14",
+		"category": "third",
+		"preferences": {"court_side": "drive", "handedness": "right"}
+	}`
+
+	h, e := newProfileTestHandler(mgr)
+	c, rec := contextWithAuthAndSub(e, http.MethodPut, "/api/v1/users/me/profile", body, userID.String())
+
+	err := h.updateMyProfile(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	mgr.AssertExpectations(t)
+}
+
+// HP-06: Invalid country code — manager returns validation error → 400.
+func TestUpdateMyProfile_InvalidCountry_Returns400(t *testing.T) {
+	userID := uuid.New()
+	mgr := &mockProfileManager{}
+	mgr.On("Update", mock.Anything, userID, mock.Anything).Return(nil, errors.New("invalid country code"))
+
+	h, e := newProfileTestHandler(mgr)
+	c, _ := contextWithAuthAndSub(e, http.MethodPut, "/api/v1/users/me/profile",
+		`{"country":"XX"}`, userID.String())
+
+	err := h.updateMyProfile(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	mgr.AssertExpectations(t)
+}
+
+// HP-07: Region without country — manager returns validation error → 400.
+func TestUpdateMyProfile_RegionWithoutCountry_Returns400(t *testing.T) {
+	userID := uuid.New()
+	mgr := &mockProfileManager{}
+	mgr.On("Update", mock.Anything, userID, mock.Anything).Return(nil, errors.New("region requires country"))
+
+	h, e := newProfileTestHandler(mgr)
+	c, _ := contextWithAuthAndSub(e, http.MethodPut, "/api/v1/users/me/profile",
+		`{"region":"ES-MD"}`, userID.String())
+
+	err := h.updateMyProfile(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	mgr.AssertExpectations(t)
+}
+
+// HP-08: Unknown enum value for gender — handler rejects before calling manager → 400.
+func TestUpdateMyProfile_InvalidGender_Returns400(t *testing.T) {
+	userID := uuid.New()
+	mgr := &mockProfileManager{}
+
+	h, e := newProfileTestHandler(mgr)
+	c, _ := contextWithAuthAndSub(e, http.MethodPut, "/api/v1/users/me/profile",
+		`{"gender":"unknown"}`, userID.String())
+
+	err := h.updateMyProfile(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	// Manager should not be called for invalid enum.
+	mgr.AssertNotCalled(t, "Update")
+}
+
+// HP-09: Empty body — manager called with all-nil patch; returns existing profile → 200.
+func TestUpdateMyProfile_EmptyBody_Returns200(t *testing.T) {
+	userID := uuid.New()
+	p := buildTestProfile(userID)
+	mgr := &mockProfileManager{}
+	mgr.On("Update", mock.Anything, userID, mock.MatchedBy(func(patch profile.ProfilePatch) bool {
+		return patch.DisplayName == nil && patch.Country == nil && patch.Region == nil &&
+			patch.Gender == nil && patch.Category == nil
+	})).Return(p, nil)
+
+	h, e := newProfileTestHandler(mgr)
+	c, rec := contextWithAuthAndSub(e, http.MethodPut, "/api/v1/users/me/profile", `{}`, userID.String())
+
+	err := h.updateMyProfile(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	mgr.AssertExpectations(t)
+}
+
+// ---- GET /users/:id/profile ----
+
+// HP-10: Returns profile for a valid user ID → 200.
+func TestGetUserProfile_ValidID_Returns200(t *testing.T) {
+	userID := uuid.New()
+	p := buildTestProfile(userID)
+	mgr := &mockProfileManager{}
+	mgr.On("GetByUserID", mock.Anything, userID).Return(p, nil)
+
+	h, e := newProfileTestHandler(mgr)
+	requesterID := uuid.New().String()
+	c, rec := contextWithAuthAndSub(e, http.MethodGet, fmt.Sprintf("/api/v1/users/%s/profile", userID), "", requesterID)
+	c.SetParamNames("id")
+	c.SetParamValues(userID.String())
+
+	err := h.getUserProfile(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), userID.String())
+	mgr.AssertExpectations(t)
+}
+
+// HP-11: Profile not found → 404.
+func TestGetUserProfile_ProfileNotFound_Returns404(t *testing.T) {
+	userID := uuid.New()
+	mgr := &mockProfileManager{}
+	mgr.On("GetByUserID", mock.Anything, userID).Return(nil, ckerrors.ErrProfileNotFound)
+
+	h, e := newProfileTestHandler(mgr)
+	requesterID := uuid.New().String()
+	c, _ := contextWithAuthAndSub(e, http.MethodGet, fmt.Sprintf("/api/v1/users/%s/profile", userID), "", requesterID)
+	c.SetParamNames("id")
+	c.SetParamValues(userID.String())
+
+	err := h.getUserProfile(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusNotFound, he.Code)
+	mgr.AssertExpectations(t)
+}
+
+// HP-12: Malformed UUID in path → 400.
+func TestGetUserProfile_MalformedUUID_Returns400(t *testing.T) {
+	mgr := &mockProfileManager{}
+	h, e := newProfileTestHandler(mgr)
+	requesterID := uuid.New().String()
+	c, _ := contextWithAuthAndSub(e, http.MethodGet, "/api/v1/users/not-a-uuid/profile", "", requesterID)
+	c.SetParamNames("id")
+	c.SetParamValues("not-a-uuid")
+
+	err := h.getUserProfile(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	mgr.AssertNotCalled(t, "GetByUserID")
+}

--- a/api/internal/api/users/handler_test.go
+++ b/api/internal/api/users/handler_test.go
@@ -81,7 +81,7 @@ var _ appauth.AuthManager = (*mockAuthManager)(nil)
 // ---- helpers ----
 
 func newTestHandler(mgr appauth.AuthManager) (*Handler, *echo.Echo) {
-	return NewHandler(mgr), echo.New()
+	return NewHandler(mgr, nil), echo.New()
 }
 
 func contextWithAuth(e *echo.Echo, method, path, body, role, sub, email string) (echo.Context, *httptest.ResponseRecorder) {

--- a/api/internal/api/users/routes.go
+++ b/api/internal/api/users/routes.go
@@ -17,4 +17,9 @@ func NewRoutes(h *Handler) *Routes {
 func (r *Routes) Register(g *echo.Group) {
 	g.GET("/users/me", r.handler.me)
 	g.PUT("/users/:id/role", r.handler.updateRole)
+
+	// Profile endpoints — all require JWT (applied at group level).
+	g.GET("/users/me/profile", r.handler.getMyProfile)
+	g.PUT("/users/me/profile", r.handler.updateMyProfile)
+	g.GET("/users/:id/profile", r.handler.getUserProfile)
 }

--- a/docs/testing/regression_map.md
+++ b/docs/testing/regression_map.md
@@ -41,3 +41,4 @@ When a feature is modified, all dependent features in this map must have their t
 | FEATURE_user_profile / T-03 | `ProfileRepository` PostgreSQL implementation (`EnsureExists`, `FindByUserID`, `Update`, `List`) | FEATURE_user_profile / T-01, T-02, FEATURE_authentication / postgres | FEATURE_user_profile / T-05 |
 | FEATURE_user_profile / T-04 | `ProfileManager` application layer (`EnsureExists`, `GetByUserID`, `Update`, `List`) | FEATURE_user_profile / T-01, T-03 | FEATURE_user_profile / T-05, T-06, T-07 |
 | FEATURE_user_profile / T-05 | Auth integration: profile initialisation on login (`AuthManager` extended, `UserManager.BootstrapAdmin` returns user, server wiring) | FEATURE_user_profile / T-03, T-04, FEATURE_authentication / application | FEATURE_authentication / cmd/server |
+| FEATURE_user_profile / T-06 | Profile HTTP endpoints (`GET /users/me/profile`, `PUT /users/me/profile`, `GET /users/:id/profile`) | FEATURE_user_profile / T-04 | — |


### PR DESCRIPTION
## Summary

- Add `profiles ProfileManager` field to `users.Handler`; update `NewHandler` to accept it as second parameter
- Implement three profile endpoints: `GET /users/me/profile`, `PUT /users/me/profile`, `GET /users/:id/profile`
- Register the new routes in `routes.go`; pass `profileManager` to `users.NewHandler` in `cmd/server/server.go`
- Error mapping: `ErrProfileNotFound` → 404; validation/enum errors → 400
- Add unit tests HP-01..HP-12 in `handler_profile_test.go`
- Update `regression_map.md` with T-06 entry

> **Note:** this branch builds on top of T-05 (`feature/CK-93/005_auth-integration` / PR #109). The diff includes T-05 changes until that PR is merged. Please merge #109 first.

## Test plan

- [x] `make test` passes — all 14 packages, no failures
- [x] HP-01: `GET /users/me/profile` returns 200 with full profile body
- [x] HP-02: `GET /users/me/profile` — profile not found → 404
- [x] HP-03/03b: Missing or invalid `sub` claim → 400
- [x] HP-04: `PUT /users/me/profile` — partial update (display_name only) → 200
- [x] HP-05: `PUT /users/me/profile` — all fields → 200
- [x] HP-06: `PUT /users/me/profile` — invalid country code → 400
- [x] HP-07: `PUT /users/me/profile` — region without country → 400
- [x] HP-08: `PUT /users/me/profile` — unknown enum (gender) rejected before manager → 400
- [x] HP-09: `PUT /users/me/profile` — empty body accepted → 200
- [x] HP-10: `GET /users/:id/profile` — valid UUID → 200
- [x] HP-11: `GET /users/:id/profile` — profile not found → 404
- [x] HP-12: `GET /users/:id/profile` — malformed UUID → 400

Closes #101
Spec: docs/specs/FEATURE_user_profile/

🤖 Generated with [Claude Code](https://claude.com/claude-code)