### PR TITLE
[CK-93] T-07 — API: list users endpoint

### DIFF
--- a/api/internal/api/users/handler.go
+++ b/api/internal/api/users/handler.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,6 +19,17 @@ import (
 	"github.com/courtknights/courtknights/internal/domain/profile"
 	"github.com/courtknights/courtknights/internal/domain/user"
 )
+
+// allowedListFields is the set of field names accepted by the list endpoint.
+var allowedListFields = map[string]struct{}{
+	"id":           {},
+	"display_name": {},
+	"city":         {},
+	"region":       {},
+	"country":      {},
+	"gender":       {},
+	"category":     {},
+}
 
 // Handler handles all user management HTTP requests.
 type Handler struct {
@@ -297,4 +310,105 @@ func toProfileResponse(p *profile.Profile) profileResponse {
 	}
 
 	return resp
+}
+
+// listUsers returns a paginated, optionally field-filtered list of user profiles.
+// GET /api/v1/users
+func (h *Handler) listUsers(c echo.Context) error {
+	page := 1
+	pageSize := 20
+
+	if v := c.QueryParam("page"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, "page must be a positive integer")
+		}
+		page = n
+	}
+
+	if v := c.QueryParam("page_size"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, "page_size must be a positive integer")
+		}
+		if n > 100 {
+			return echo.NewHTTPError(http.StatusBadRequest, "page_size must not exceed 100")
+		}
+		pageSize = n
+	}
+
+	var fields []string
+	if v := c.QueryParam("fields"); v != "" {
+		for _, f := range strings.Split(v, ",") {
+			f = strings.TrimSpace(f)
+			if _, ok := allowedListFields[f]; !ok {
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("unknown field: %q", f))
+			}
+			fields = append(fields, f)
+		}
+	}
+
+	items, total, err := h.profiles.List(c.Request().Context(), profile.ListParams{
+		Page:     page,
+		PageSize: pageSize,
+		Fields:   fields,
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to list users")
+	}
+
+	data := make([]listItemResponse, len(items))
+	for i, item := range items {
+		data[i] = toListItemResponse(item)
+	}
+
+	return c.JSON(http.StatusOK, listUsersResponse{
+		Data:     data,
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+	})
+}
+
+// listUsersResponse is the JSON envelope for the list-users endpoint.
+type listUsersResponse struct {
+	Data     []listItemResponse `json:"data"`
+	Total    int64              `json:"total"`
+	Page     int                `json:"page"`
+	PageSize int                `json:"page_size"`
+}
+
+// listItemResponse is a single entry in the list-users response.
+// All profile fields are optional (omitted when nil / not requested).
+type listItemResponse struct {
+	ID          *string `json:"id,omitempty"`
+	DisplayName *string `json:"display_name,omitempty"`
+	City        *string `json:"city,omitempty"`
+	Region      *string `json:"region,omitempty"`
+	Country     *string `json:"country,omitempty"`
+	Gender      *string `json:"gender,omitempty"`
+	Category    *string `json:"category,omitempty"`
+}
+
+// toListItemResponse converts a domain ProfileListItem to its API response form.
+func toListItemResponse(item *profile.ProfileListItem) listItemResponse {
+	r := listItemResponse{
+		DisplayName: item.DisplayName,
+		City:        item.City,
+		Region:      item.Region,
+		Country:     item.Country,
+	}
+	if item.ID != nil {
+		s := item.ID.String()
+		r.ID = &s
+	}
+	if item.Gender != nil {
+		s := string(*item.Gender)
+		r.Gender = &s
+	}
+	if item.Category != nil {
+		s := string(*item.Category)
+		r.Category = &s
+	}
+	return r
 }

--- a/api/internal/api/users/handler_list_test.go
+++ b/api/internal/api/users/handler_list_test.go
@@ -1,0 +1,190 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/courtknights/courtknights/internal/domain/profile"
+)
+
+// ---- helpers ----
+
+func newListTestHandler(profiles *mockProfileManager) (*Handler, *echo.Echo) {
+	return NewHandler(&mockAuthManager{}, profiles), echo.New()
+}
+
+func buildListRequest(e *echo.Echo, query string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users"+query, nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+func buildListItem(id uuid.UUID, displayName, country string) *profile.ProfileListItem {
+	dn := displayName
+	c := country
+	return &profile.ProfileListItem{ID: &id, DisplayName: &dn, Country: &c}
+}
+
+// ---- tests ----
+
+// LU-01: Default params — page=1, page_size=20, all fields.
+func TestListUsers_DefaultParams_Returns200(t *testing.T) {
+	id1, id2 := uuid.New(), uuid.New()
+	items := []*profile.ProfileListItem{
+		buildListItem(id1, "Alice", "ES"),
+		buildListItem(id2, "Bob", "PT"),
+	}
+	mgr := &mockProfileManager{}
+	mgr.On("List", mock.Anything, profile.ListParams{Page: 1, PageSize: 20, Fields: nil}).
+		Return(items, int64(2), nil)
+
+	h, e := newListTestHandler(mgr)
+	c, rec := buildListRequest(e, "")
+
+	err := h.listUsers(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listUsersResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, int64(2), resp.Total)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 20, resp.PageSize)
+	assert.Len(t, resp.Data, 2)
+	mgr.AssertExpectations(t)
+}
+
+// LU-02: Explicit page and page_size.
+func TestListUsers_ExplicitPageAndPageSize_Returns200(t *testing.T) {
+	mgr := &mockProfileManager{}
+	mgr.On("List", mock.Anything, profile.ListParams{Page: 2, PageSize: 5, Fields: nil}).
+		Return([]*profile.ProfileListItem{}, int64(10), nil)
+
+	h, e := newListTestHandler(mgr)
+	c, rec := buildListRequest(e, "?page=2&page_size=5")
+
+	err := h.listUsers(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listUsersResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.Page)
+	assert.Equal(t, 5, resp.PageSize)
+	assert.Equal(t, int64(10), resp.Total)
+	mgr.AssertExpectations(t)
+}
+
+// LU-03: Field selection — manager called with requested fields.
+func TestListUsers_FieldSelection_Returns200(t *testing.T) {
+	id := uuid.New()
+	idStr := id.String()
+	dn := "Alice"
+	country := "ES"
+	item := &profile.ProfileListItem{ID: &id, DisplayName: &dn, Country: &country}
+
+	mgr := &mockProfileManager{}
+	mgr.On("List", mock.Anything, profile.ListParams{
+		Page:     1,
+		PageSize: 20,
+		Fields:   []string{"id", "display_name", "country"},
+	}).Return([]*profile.ProfileListItem{item}, int64(1), nil)
+
+	h, e := newListTestHandler(mgr)
+	c, rec := buildListRequest(e, "?fields=id,display_name,country")
+
+	err := h.listUsers(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listUsersResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, &idStr, resp.Data[0].ID)
+	assert.Equal(t, &dn, resp.Data[0].DisplayName)
+	assert.Equal(t, &country, resp.Data[0].Country)
+	mgr.AssertExpectations(t)
+}
+
+// LU-04: page_size exceeds 100 → 400.
+func TestListUsers_PageSizeExceedsMax_Returns400(t *testing.T) {
+	mgr := &mockProfileManager{}
+	h, e := newListTestHandler(mgr)
+	c, _ := buildListRequest(e, "?page_size=101")
+
+	err := h.listUsers(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	mgr.AssertNotCalled(t, "List")
+}
+
+// LU-05: page less than 1 → 400.
+func TestListUsers_PageLessThanOne_Returns400(t *testing.T) {
+	mgr := &mockProfileManager{}
+	h, e := newListTestHandler(mgr)
+	c, _ := buildListRequest(e, "?page=0")
+
+	err := h.listUsers(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	mgr.AssertNotCalled(t, "List")
+}
+
+// LU-06: Unknown field name → 400.
+func TestListUsers_UnknownField_Returns400(t *testing.T) {
+	mgr := &mockProfileManager{}
+	h, e := newListTestHandler(mgr)
+	c, _ := buildListRequest(e, "?fields=id,unknown_field")
+
+	err := h.listUsers(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusBadRequest, he.Code)
+	mgr.AssertNotCalled(t, "List")
+}
+
+// LU-07: Empty result set → 200 with data:[] and total:0.
+func TestListUsers_EmptyResult_Returns200(t *testing.T) {
+	mgr := &mockProfileManager{}
+	mgr.On("List", mock.Anything, profile.ListParams{Page: 1, PageSize: 20, Fields: nil}).
+		Return([]*profile.ProfileListItem{}, int64(0), nil)
+
+	h, e := newListTestHandler(mgr)
+	c, rec := buildListRequest(e, "")
+
+	err := h.listUsers(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listUsersResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, int64(0), resp.Total)
+	assert.Empty(t, resp.Data)
+	mgr.AssertExpectations(t)
+}
+
+// LU-08: Manager returns error → 500.
+func TestListUsers_ManagerError_Returns500(t *testing.T) {
+	mgr := &mockProfileManager{}
+	mgr.On("List", mock.Anything, mock.Anything).
+		Return(nil, int64(0), assert.AnError)
+
+	h, e := newListTestHandler(mgr)
+	c, _ := buildListRequest(e, "")
+
+	err := h.listUsers(c)
+	var he *echo.HTTPError
+	require.ErrorAs(t, err, &he)
+	assert.Equal(t, http.StatusInternalServerError, he.Code)
+	mgr.AssertExpectations(t)
+}

--- a/api/internal/api/users/routes.go
+++ b/api/internal/api/users/routes.go
@@ -15,6 +15,7 @@ func NewRoutes(h *Handler) *Routes {
 // Register mounts all user management routes on the given group.
 // Called by the router for the protected /api/v1 prefix (JWT middleware applied).
 func (r *Routes) Register(g *echo.Group) {
+	g.GET("/users", r.handler.listUsers)
 	g.GET("/users/me", r.handler.me)
 	g.PUT("/users/:id/role", r.handler.updateRole)
 

--- a/docs/testing/regression_map.md
+++ b/docs/testing/regression_map.md
@@ -42,3 +42,4 @@ When a feature is modified, all dependent features in this map must have their t
 | FEATURE_user_profile / T-04 | `ProfileManager` application layer (`EnsureExists`, `GetByUserID`, `Update`, `List`) | FEATURE_user_profile / T-01, T-03 | FEATURE_user_profile / T-05, T-06, T-07 |
 | FEATURE_user_profile / T-05 | Auth integration: profile initialisation on login (`AuthManager` extended, `UserManager.BootstrapAdmin` returns user, server wiring) | FEATURE_user_profile / T-03, T-04, FEATURE_authentication / application | FEATURE_authentication / cmd/server |
 | FEATURE_user_profile / T-06 | Profile HTTP endpoints (`GET /users/me/profile`, `PUT /users/me/profile`, `GET /users/:id/profile`) | FEATURE_user_profile / T-04 | — |
+| FEATURE_user_profile / T-07 | List users endpoint (`GET /users` with pagination and field selection) | FEATURE_user_profile / T-04 | — |


### PR DESCRIPTION
## Summary

- Implement `listUsers` handler — `GET /api/v1/users` with pagination (`page`, `page_size`) and optional field selection (`fields`)
- Validation: `page < 1` → 400; `page_size > 100` → 400; unknown field name → 400; defaults: `page=1`, `page_size=20`
- Add `listUsersResponse` / `listItemResponse` types with `omitempty` so nil/unselected fields are absent from the JSON output
- Register `GET /users` route in `routes.go` (before `/users/me` to avoid shadowing)
- Add unit tests LU-01..LU-08 in `handler_list_test.go`
- Update `regression_map.md` with T-07 entry

## Test plan

- [x] `make test` passes — all 14 packages, no failures
- [x] LU-01: default params → 200; `page=1`, `page_size=20`, `total=2`
- [x] LU-02: explicit `page=2&page_size=5` → 200; response reflects params
- [x] LU-03: `fields=id,display_name,country` → manager called with correct fields
- [x] LU-04: `page_size=101` → 400
- [x] LU-05: `page=0` → 400
- [x] LU-06: `fields=id,unknown_field` → 400
- [x] LU-07: empty result set → 200 with `"data":[]`, `"total":0`
- [x] LU-08: manager error → 500

Closes #102
Spec: docs/specs/FEATURE_user_profile/

🤖 Generated with [Claude Code](https://claude.com/claude-code)